### PR TITLE
Ignore hydrogen atoms when finding nearest atom

### DIFF
--- a/Client/vr-client/.idea/.idea.vr-client/.idea/workspace.xml
+++ b/Client/vr-client/.idea/.idea.vr-client/.idea/workspace.xml
@@ -6,6 +6,11 @@
   <component name="ChangeListManager">
     <list default="true" id="8e3d862e-de99-4872-872c-e26f3efad996" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/.idea.vr-client/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.vr-client/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/NarupaIMD/Interaction/InteractableScene.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/NarupaIMD/Interaction/InteractableScene.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Resources/OculusRuntimeSettings.asset" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Resources/OculusRuntimeSettings.asset" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Resources/OculusRuntimeSettings.asset.meta" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Resources/OculusRuntimeSettings.asset.meta" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scenes/Main.unity" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scenes/Main.unity" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json" beforeDir="false" afterPath="$PROJECT_DIR$/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -13,8 +18,8 @@
     <option name="LAST_RESOLUTION" value="IGNORE" />
   </component>
   <component name="HighlightingSettingsPerFile">
-    <setting file="file://$PROJECT_DIR$/Assets/NarupaIMD/GameLogic/CheckHandTrackingEnabled.cs" root0="FORCE_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/Assets/Oculus/VR/Scripts/OVRPlugin.cs" root0="SKIP_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/../../../extraction/Assets/NarupaIMD/NarupaImdSimulation.cs" root0="SKIP_HIGHLIGHTING" />
   </component>
   <component name="ProjectColorInfo">{
   &quot;customColor&quot;: &quot;&quot;,
@@ -40,8 +45,8 @@
   },
   "keyToStringList": {
     "rider.external.source.directories": [
-      "C:\\Users\\rhosl\\AppData\\Roaming\\JetBrains\\Rider2023.2\\resharper-host\\DecompilerCache",
-      "C:\\Users\\rhosl\\AppData\\Roaming\\JetBrains\\Rider2023.2\\resharper-host\\SourcesCache",
+      "C:\\Users\\rhosl\\AppData\\Roaming\\JetBrains\\Rider2023.1\\resharper-host\\DecompilerCache",
+      "C:\\Users\\rhosl\\AppData\\Roaming\\JetBrains\\Rider2023.1\\resharper-host\\SourcesCache",
       "C:\\Users\\rhosl\\AppData\\Local\\Symbols\\src"
     ]
   }
@@ -95,6 +100,7 @@
       <workItem from="1698846911876" duration="7041000" />
       <workItem from="1698916637476" duration="9269000" />
       <workItem from="1698926468546" duration="1743000" />
+      <workItem from="1699018666724" duration="4756000" />
     </task>
     <servers />
   </component>

--- a/Client/vr-client/Assets/NarupaIMD/Interaction/InteractableScene.cs
+++ b/Client/vr-client/Assets/NarupaIMD/Interaction/InteractableScene.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Narupa.Core.Math;
+using Narupa.Core.Science;
 using Narupa.Frontend.Manipulation;
 using Narupa.Visualisation;
 using Narupa.Visualisation.Properties;
@@ -32,6 +33,8 @@ namespace NarupaImd.Interaction
             Single,
             Residue
         }
+
+        private Element _hydrogenElement = Element.Hydrogen;
 
         [SerializeField]
         private InteractionTarget interactionTarget = InteractionTarget.Single;
@@ -158,6 +161,9 @@ namespace NarupaImd.Interaction
 
             for (var i = 0; i < frame.ParticlePositions.Length; ++i)
             {
+                // If particle is a hydrogen, ignore it
+                if (simulation.Trajectory.CurrentFrame.ParticleElements[i] == _hydrogenElement){continue;}
+                
                 var particlePosition = frame.ParticlePositions[i];
                 var sqrDistance = Vector3.SqrMagnitude(position - particlePosition);
 


### PR DESCRIPTION
When the VR client attempts to find the nearest atom it will ignore hydrogen atoms, meaning that a player cannot interact with hydrogens.