### PR TITLE
Refactored how the simulation box is put in front of player

### DIFF
--- a/Client/vr-client/Assets/NarupaIMD/Subtle Game/Logic/PuppeteerManager.cs
+++ b/Client/vr-client/Assets/NarupaIMD/Subtle Game/Logic/PuppeteerManager.cs
@@ -5,7 +5,9 @@ using Narupa.Grpc.Multiplayer;
 using NarupaImd;
 using NarupaIMD.Subtle_Game.Interaction;
 using NarupaIMD.Subtle_Game.UI;
+using NarupaIMD.Subtle_Game.Visuals;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace NarupaIMD.Subtle_Game.Logic
 {
@@ -16,12 +18,13 @@ namespace NarupaIMD.Subtle_Game.Logic
     public class PuppeteerManager : MonoBehaviour
     {
         // SET YOUR LOCAL IP!
-        private string _ipAddress = "192.168.68.57";
+        private string _ipAddress = "192.168.68.55";
         
         #region Scene References
         
         public NarupaImdSimulation simulation;
         public GameObject userInteraction;
+        public SimulationBoxCentre simulationBoxCentre;
         
         private Transform _simulationSpace;
         private CanvasManager _canvasManager;
@@ -304,36 +307,8 @@ namespace NarupaIMD.Subtle_Game.Logic
             // Disable interactions
             EnableInteractions = false;
 
-            // Set position and rotation of simulation to be in front of the player.
-            MoveSimulationInFrontOfPlayer();
-        }
-
-        /// <summary>
-        /// Center the simulation space in front of the player.
-        /// </summary>
-        private void MoveSimulationInFrontOfPlayer()
-        {
-            if (Camera.main == null) return;
-            Transform cameraTransform = Camera.main.transform;
-
-            // Calculate the target position in front of the camera
-            Vector3 targetPosition = cameraTransform.position + (cameraTransform.forward * DistanceFromCamera);
-
-            // Make sure the object does not move up or down; keep the Y coordinate the same
-            targetPosition.y = _simulationSpace.position.y;
-
-            // Move the object to the target position
-            _simulationSpace.position = targetPosition;
-
-            // Get the Y rotation of the camera
-            float cameraYRotation = cameraTransform.eulerAngles.y;
-
-            // Construct a new rotation for the object, preserving its original X and Z rotation
-            var eulerAngles = _simulationSpace.eulerAngles;
-            Quaternion targetRotation = Quaternion.Euler(eulerAngles.x, cameraYRotation, eulerAngles.z);
-
-            // Apply the rotation to the object
-            _simulationSpace.rotation = targetRotation;
+            // Center simulation box in front of player
+            simulationBoxCentre.CenterInFrontOfPlayer();
         }
     }
 }

--- a/Client/vr-client/Assets/NarupaIMD/Subtle Game/Visuals/SimulationBoxCentre.cs
+++ b/Client/vr-client/Assets/NarupaIMD/Subtle Game/Visuals/SimulationBoxCentre.cs
@@ -1,0 +1,33 @@
+using Narupa.Core.Math;
+using UnityEngine;
+
+namespace NarupaIMD.Subtle_Game.Visuals
+{
+    public class SimulationBoxCentre : MonoBehaviour
+    {
+        [SerializeField]
+        private AffineTransformation simulationBox;
+
+        [SerializeField] 
+        private Transform simulation;
+        
+        [SerializeField]
+        private Transform centreEyeAnchor;
+
+        private void Start()
+        {
+            // Set position to center of simulation box (note the negative in the x dimension)
+            transform.position = new Vector3(
+                -simulationBox.axesMagnitudes.x/2, 
+                simulationBox.axesMagnitudes.y/2, 
+                simulationBox.axesMagnitudes.z/2
+                ) ;
+        }
+
+        public void CenterInFrontOfPlayer()
+        {
+            // Set simulation to the difference between the centre of the headset and the centre of the box, plus an offset in the direction of the gaze of the headset
+            simulation.position = (centreEyeAnchor.position - transform.position) + centreEyeAnchor.forward * 0.7f;
+        }
+    }
+}

--- a/Client/vr-client/Assets/NarupaIMD/Subtle Game/Visuals/SimulationBoxCentre.cs.meta
+++ b/Client/vr-client/Assets/NarupaIMD/Subtle Game/Visuals/SimulationBoxCentre.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8a79a2e67ebce3f46ab02ff7bf8d25e1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/vr-client/Assets/Scenes/Main.unity
+++ b/Client/vr-client/Assets/Scenes/Main.unity
@@ -123,6 +123,131 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &21014615
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 21014617}
+  - component: {fileID: 21014620}
+  - component: {fileID: 21014619}
+  - component: {fileID: 21014618}
+  - component: {fileID: 21014616}
+  m_Layer: 0
+  m_Name: Box Centre
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &21014616
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 21014615}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8a79a2e67ebce3f46ab02ff7bf8d25e1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  simulationBox:
+    xAxis: {x: 1, y: 0, z: 0}
+    yAxis: {x: 0, y: 1, z: 0}
+    zAxis: {x: 0, y: 0, z: 1}
+    origin: {x: 0, y: 0, z: 0}
+  simulation: {fileID: 1265723034}
+  centreEyeAnchor: {fileID: 4948775120161647665}
+--- !u!4 &21014617
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 21014615}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.2, y: 0.2, z: 0.2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1464610667}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!135 &21014618
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 21014615}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 0
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &21014619
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 21014615}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &21014620
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 21014615}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &23693883
 GameObject:
   m_ObjectHideFlags: 0
@@ -5771,6 +5896,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   simulation: {fileID: 1265723033}
   userInteraction: {fileID: 50482150}
+  simulationBoxCentre: {fileID: 21014616}
   grabbersReady: 0
 --- !u!114 &1373612429 stripped
 MonoBehaviour:
@@ -6479,6 +6605,7 @@ Transform:
   - {fileID: 23693885}
   - {fileID: 589699540}
   - {fileID: 543794535019733081}
+  - {fileID: 21014617}
   m_Father: {fileID: 1152867538}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1473700902


### PR DESCRIPTION
This was previously being done by the PuppeteerManager, but is now handled by a separate script (SimulationBoxCentre.cs). The PuppeteerManager calls the function at the same point as previously.

The script puts the simulation in front of the player by using the centre of the box and applying an offset relative to the forward direction of the headset (using the Center Eye Anchor).