### PR TITLE
Add loading of specific simulation

### DIFF
--- a/Client/puppeteering_client.py
+++ b/Client/puppeteering_client.py
@@ -30,8 +30,17 @@ class PuppeteeringClient:
         for task in self.order_of_tasks:
 
             if task == 'nanotube':
-                current_task = NanotubeTask(self.narupa_client)
-                print('Starting nanotube task')
+
+                # Check that the nanotube simulation was loaded into the server
+                if self.nanotube_index is None:
+                    raise ValueError("No nanotube simulation found. Have you forgotten to load the nanotube "
+                                     "simulation on the server? Is the loaded .xml file called 'nanotube.xml'?")
+
+                # Create task
+                current_task = NanotubeTask(self.narupa_client, simulation_index=self.nanotube_index[0])
+
+                # Run task
+                print('Running nanotube task')
                 current_task.run_task()
                 print('Finished nanotube task')
 
@@ -40,11 +49,17 @@ class PuppeteeringClient:
         print('Finished game')
 
     def _initialise_game(self):
-        """ Writes the key-value pairs to the shared state that are required to begin the game. """
+        """ Writes the key-value pairs to the shared state that are required to begin the game. Gets simulation
+        indexes from server."""
+
         # update the shared state
         write_to_shared_state(self.narupa_client, 'game-status', 'waiting')
         write_to_shared_state(self.narupa_client, 'modality', self.current_modality)
         write_to_shared_state(self.narupa_client, 'order-of-tasks', self.order_of_tasks)
+
+        # Get simulation indices from server.
+        simulations = self.narupa_client.run_command('playback/list')
+        self.nanotube_index = [idx for idx, s in enumerate(simulations['simulations']) if 'nanotube' in s]
 
     def _finish_game(self):
         """ Update the shared state and close the client at the end of the game. """

--- a/Client/task.py
+++ b/Client/task.py
@@ -5,6 +5,8 @@ import time
 
 class Task:
 
+    sim_index = None
+
     def __init__(self, client: NarupaImdClient):
         self.client = client
 
@@ -32,7 +34,7 @@ class Task:
         write_to_shared_state(self.client, 'task-status', 'in-progress')
 
         # Play simulation
-        self.client.run_command("playback/play")
+        self.client.run_play()
 
         # Monitor whether task is completed
         self._run_logic_for_specific_task()
@@ -42,14 +44,16 @@ class Task:
 
     def _prepare_task(self):
 
-        # # Load simulation
-        # self.client.run_command("playback/load", index=self.simulation_id)
+        # Load simulation
+        self.client.run_command("playback/load", index=self.sim_index)
 
         # Update visualisation
         self._update_visualisations()
 
-        # Reset and pause simulation
+        # Reset simulation
         self.client.run_reset()
+
+        # Pause simulation
         self.client.run_command("playback/pause")
 
         # Update task type
@@ -64,7 +68,15 @@ class Task:
 
     def _run_logic_for_specific_task(self):
         """Container for the logic specific to each task."""
-        pass
+
+        # Check that frames are being received
+        while True:
+            try:
+                test = self.client.latest_frame.particle_positions
+                break
+            except KeyError:
+                print("No particle positions found, waiting for 1/30 seconds before trying again.")
+                time.sleep(1 / 30)
 
     def _finish_task(self):
         """Handles the finishing of the task."""

--- a/Client/task_nanotube.py
+++ b/Client/task_nanotube.py
@@ -7,15 +7,17 @@ import time
 
 class NanotubeTask(Task):
 
-    def __init__(self, client: NarupaImdClient):
+    def __init__(self, client: NarupaImdClient, simulation_index: int):
 
         super().__init__(client)
-
+        self.sim_index = simulation_index
         self.was_methane_in_nanotube = False
         self.is_methane_in_nanotube = False
         self.methane_end_of_entry = None
 
     def _run_logic_for_specific_task(self):
+
+        super()._run_logic_for_specific_task()
 
         while True:
 


### PR DESCRIPTION
The puppeteering client now reads the list of simulations that have been loaded onto the server. The index corresponding to the correct simulation is given to the relevant task to be loaded onto the server.

There is a slight delay in receiving the frames when the task is first started, so a check is made in the Task class to make sure that the frames are being received. From testing, only one cycle of this loop is required before the frames are received.