### PR TITLE
Player can select trial answer with controllers

### DIFF
--- a/Client/vr-client/Assets/NarupaIMD/Subtle Game/UI/TrialAnswerSubmission.cs
+++ b/Client/vr-client/Assets/NarupaIMD/Subtle Game/UI/TrialAnswerSubmission.cs
@@ -21,6 +21,8 @@ namespace NarupaIMD.Subtle_Game.UI
         [SerializeField] private CentreOfGeometry centreOfGeometryB;
         [SerializeField] private Transform rightIndexTip;
         [SerializeField] private Transform leftIndexTip;
+        [SerializeField] private Transform rightController;
+        [SerializeField] private Transform leftController;
         
         private ColorInput _colorMoleculeA;
         private ColorInput _colorMoleculeB;
@@ -215,12 +217,27 @@ namespace NarupaIMD.Subtle_Game.UI
         }
 
         /// <summary>
-        /// Checks if either hand is inside the molecule.
+        /// Checks if either hand is inside the molecule. Checks either the hands or the controllers depending on the
+        /// modality set in the Puppeteer Manager.
         /// </summary>
         private bool IsHandInsideMolecule(CentreOfGeometry cog)
         {
-            bool rightHandInside = cog.IsPointInsideShape(rightIndexTip.position);
-            bool leftHandInside = cog.IsPointInsideShape(leftIndexTip.position);
+            bool rightHandInside;
+            bool leftHandInside;
+            
+            // Hands
+            if (_puppeteerManager.CurrentInteractionModality == PuppeteerManager.Modality.Hands)
+            {
+                rightHandInside = cog.IsPointInsideShape(rightIndexTip.position);
+                leftHandInside = cog.IsPointInsideShape(leftIndexTip.position);
+            }
+            // Controllers
+            else
+            {
+                rightHandInside = cog.IsPointInsideShape(rightController.position);
+                leftHandInside = cog.IsPointInsideShape(leftController.position);
+            }
+            
             return rightHandInside || leftHandInside;
         }
     }

--- a/Client/vr-client/Assets/Scenes/Main.unity
+++ b/Client/vr-client/Assets/Scenes/Main.unity
@@ -6465,7 +6465,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3e1c2e6973f58904fae20f1850923351, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  UseControllers: 0
   PokePositions:
   - {fileID: 7416501715839334339}
   - {fileID: 9116940136169035185}
@@ -8491,6 +8490,8 @@ MonoBehaviour:
   centreOfGeometryB: {fileID: 230018909}
   rightIndexTip: {fileID: 4682591776209724542}
   leftIndexTip: {fileID: 4591869718317071806}
+  rightController: {fileID: 9116940136169035185}
+  leftController: {fileID: 7416501715839334339}
 --- !u!1 &1371801897
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Previously the player could only select their answer for the trials using their hands. Now the code checks the interaction modality set in the Puppeteer Manager and uses the correct modality to check for an answer submission.