### PR TITLE
Clear selections for knot tying task and add check for particle positions

### DIFF
--- a/Client/task_knot_tying.py
+++ b/Client/task_knot_tying.py
@@ -44,7 +44,6 @@ class KnotTyingTask(Task):
 
             if self.knot_pull_client.is_currently_knotted:
                 self.client.set_shared_value('task status', 'completed')
-                time.sleep(3)
                 break
 
             time.sleep(1 / 30)


### PR DESCRIPTION
The selections are cleared for the knot-tying task, so the default rendering is used. 

Also, an added check to ensure that the particle positions key is present in the shared state has been added to the puppeteering client. In the second iteration of this while loop, only the topology is present in the shared state (not sure why). So adding this check means that this iteration is skipped. In testing, this only ever skips one loop, in all other loops the particle positions are present in the shared state.