### PR TITLE
Loop through number of alpha carbons, not residues

### DIFF
--- a/Client/knot_pull_client.py
+++ b/Client/knot_pull_client.py
@@ -98,7 +98,7 @@ class KnotPullClient:
         self.kp_beads = []
 
         # Loop through number of alpha carbons.
-        for atom_num in range(self.number_of_residues):
+        for atom_num in range(len(self.positions_alpha_carbons)):
             # Get xyz positions of alpha carbon.
             x = self.positions_alpha_carbons[atom_num][0]
             y = self.positions_alpha_carbons[atom_num][1]


### PR DESCRIPTION
There was an issue where sometimes the number of residues was not the same as the number of alpha carbons. This should not be the case, but it is more rigorous to run through the number of alpha carbons anyway. Knot detection still works well from testing it in VR.