### PR TITLE
Wait for player to register end of task

### DIFF
--- a/Client/task.py
+++ b/Client/task.py
@@ -39,7 +39,7 @@ class Task:
         write_to_shared_state(self.client, 'current-task', self.task_type)
 
         # Update task status
-        self.client.set_shared_value('task-status', 'ready')
+        write_to_shared_state(self.client, 'task-status', 'ready')
 
         print("Task prepared")
 


### PR DESCRIPTION
The puppeteering client now waits for the VR client to register the end of the task before preparing the next task. A bug was also fixed in the puppeteering client.