### PR TITLE
Put in catch for ValueError in knot_pull

### DIFF
--- a/Client/knot_pull_client.py
+++ b/Client/knot_pull_client.py
@@ -51,7 +51,12 @@ class KnotPullClient:
         self.update_positions_of_alpha_carbons()
 
         # Run edited knot_pull functions.
-        self.run_knot_pull_functions()
+        try:
+            self.run_knot_pull_functions()
+
+        except ValueError as e:
+            print(f"Caught an exception: {e}. Skipping this iteration of the knot detection.")
+            return
 
         # Check for change in knot state.
         self.check_for_change_in_knot_state(init=first_check)


### PR DESCRIPTION
Occasionally a 'Dowker broke' ValueError is raised from the knot_pull code. This is a fix that will catch this error and skip the current knot-detection loop. This stops the entire puppeteering client from stopping when this error is raised.