### PR TITLE
Write avatar data to the shared state

### DIFF
--- a/Client/vr-client/Assets/NarupaIMD/Subtle Game/Data Collection.meta
+++ b/Client/vr-client/Assets/NarupaIMD/Subtle Game/Data Collection.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 52181909de1d40c2aef40a0202a8e007
+timeCreated: 1706197526

--- a/Client/vr-client/Assets/NarupaIMD/Subtle Game/Data Collection/Avatar.cs
+++ b/Client/vr-client/Assets/NarupaIMD/Subtle Game/Data Collection/Avatar.cs
@@ -1,0 +1,79 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using NarupaImd;
+using UnityEngine;
+
+namespace NarupaIMD.Subtle_Game.Data_Collection
+{
+    public class Avatar : MonoBehaviour
+    {
+        [SerializeField] 
+        private Transform centerEyeAnchor;
+        private const SubtleGameManager.SharedStateKey CenterHeadset = SubtleGameManager.SharedStateKey.CentreEyeAnchor;
+        
+        [SerializeField] 
+        private Transform rightHandAnchor;
+        private const SubtleGameManager.SharedStateKey RightHand = SubtleGameManager.SharedStateKey.RightHandAnchor;
+
+        
+        [SerializeField] 
+        private Transform leftHandAnchor;
+        private const SubtleGameManager.SharedStateKey LeftHand = SubtleGameManager.SharedStateKey.LeftHandAnchor;
+
+        [SerializeField] private NarupaImdSimulation simulation;
+        private SubtleGameManager _subtleGameManager;
+
+
+        private void Start()
+        {
+            _subtleGameManager = FindObjectOfType<SubtleGameManager>();
+            _subtleGameManager.PlayerConnected += StartRecordingAvatar;
+        }
+        
+        /// <summary>
+        /// Starts the coroutine for recording the avatars positions to the shared state.
+        /// </summary>
+        private void StartRecordingAvatar()
+        {
+            StartCoroutine(RecordAvatar());
+        }
+
+        /// <summary>
+        /// Writes position of center eye anchor, right hand anchor and left hand anchor to the shared state 30 times a
+        /// second. Starts once the VR client connects to the server and stops when it disconnects.
+        /// </summary>
+        private IEnumerator RecordAvatar()
+        {
+            while (_subtleGameManager.PlayerStatus)
+            {
+                WriteTransformToSharedState(CenterHeadset, centerEyeAnchor);
+                WriteTransformToSharedState(RightHand, rightHandAnchor);
+                WriteTransformToSharedState(LeftHand, leftHandAnchor);
+                yield return new WaitForSeconds(1f/30f);
+            }
+
+            yield return null;
+        }
+        
+        /// <summary>
+        /// Gets the x,y,z positions of the transform and writes this to shared state with the specified key.
+        /// </summary>
+        private void WriteTransformToSharedState(SubtleGameManager.SharedStateKey key, Transform objectTransform)
+        {
+            var position = objectTransform.position;
+            var rotation = objectTransform.rotation;
+            WriteToSharedState(key, 
+                string.Join(",", 
+                    new List<float> { position.x, position.y, position.z , rotation.x, rotation.y, rotation.z}));
+        }
+        
+        /// <summary>
+        /// Writes key-value pair to the shared state with the 'Avatar.' identifier at the front of the key. 
+        /// </summary>
+        private void WriteToSharedState(SubtleGameManager.SharedStateKey key, string value)
+        {
+            var formattedKey = new string("Avatar." + key);
+            simulation.Multiplayer.SetSharedState(formattedKey, value);
+        }
+    }
+}

--- a/Client/vr-client/Assets/NarupaIMD/Subtle Game/Data Collection/Avatar.cs.meta
+++ b/Client/vr-client/Assets/NarupaIMD/Subtle Game/Data Collection/Avatar.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b80b84e108c1499aa7c0c5d5af37496d
+timeCreated: 1706197554

--- a/Client/vr-client/Assets/NarupaIMD/Subtle Game/SubtleGameManager.cs
+++ b/Client/vr-client/Assets/NarupaIMD/Subtle Game/SubtleGameManager.cs
@@ -65,13 +65,16 @@ namespace NarupaIMD.Subtle_Game
         #endregion
 
         #region Shared State Keys and Values
-            private enum SharedStateKey
+            public enum SharedStateKey
             {
                 TaskStatus,
                 TaskType,
                 Connected,
                 TrialAnswer,
-                HeadsetType
+                HeadsetType,
+                CentreEyeAnchor,
+                RightHandAnchor,
+                LeftHandAnchor
             }
             public enum TaskStatusVal
             {
@@ -108,7 +111,7 @@ namespace NarupaIMD.Subtle_Game
                     WriteToSharedState(SharedStateKey.HeadsetType, _hmdType);
                 }
             }
-            #endregion
+        #endregion
         
         #region Task-related
             private List<string> OrderOfTasks { get; set; }
@@ -145,15 +148,21 @@ namespace NarupaIMD.Subtle_Game
         #endregion
         
         #region Player Status
+
+        public event Action PlayerConnected;
             public bool PlayerStatus
             {
-                set
+                get => _playerStatus;
+                private set
                 {
                     if (_playerStatus == value) return;
                     _playerStatus = value;
                     WriteToSharedState(SharedStateKey.Connected, value.ToString());
+                    if (!_playerStatus) return;
+                    PlayerConnected?.Invoke();
                 }
             }
+
             private bool _playerStatus;
         #endregion
         

--- a/Client/vr-client/Assets/Scenes/Main.unity
+++ b/Client/vr-client/Assets/Scenes/Main.unity
@@ -7033,6 +7033,7 @@ GameObject:
   - component: {fileID: 1364228085}
   - component: {fileID: 1364228086}
   - component: {fileID: 1364228087}
+  - component: {fileID: 1364228088}
   m_Layer: 0
   m_Name: GAME
   m_TagString: Untagged
@@ -7092,6 +7093,21 @@ MonoBehaviour:
   leftIndexTip: {fileID: 4591869718317071806}
   rightController: {fileID: 9116940136169035185}
   leftController: {fileID: 7416501715839334339}
+--- !u!114 &1364228088
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1364228083}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b80b84e108c1499aa7c0c5d5af37496d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  centerEyeAnchor: {fileID: 4948775120161647665}
+  rightHandAnchor: {fileID: 8677729729140572697}
+  leftHandAnchor: {fileID: 8895552804684926773}
 --- !u!1 &1371801897
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
The VR client now writes the positions and rotations of the centre eye anchor, right hand anchor and left hand anchor to the shared state 30 times a second. These are currently formatted in a very basic way as a proof of concept, but this can be changed easily when we know what we want to do with the data.