### PR TITLE
Enable avatar manager for writing scene to shared state

### DIFF
--- a/Client/vr-client/Assets/Scenes/Main.unity
+++ b/Client/vr-client/Assets/Scenes/Main.unity
@@ -17903,7 +17903,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1364228083}
-  m_Enabled: 0
+  m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: cd66041001c24834a442f4d36c54c106, type: 3}
   m_Name: 


### PR DESCRIPTION
The bug has been fixed that was causing issues with the writing of the avatar data to the shared state. In this pull request the avatar manager is enabled in the scene.