### PR TITLE
Add a delay between trials

### DIFF
--- a/Client/vr-client/Assets/NarupaIMD/Subtle Game/SubtleGameManager.cs
+++ b/Client/vr-client/Assets/NarupaIMD/Subtle Game/SubtleGameManager.cs
@@ -412,8 +412,12 @@ namespace NarupaIMD.Subtle_Game
         
         IEnumerator StartTrialWithDelay()
         {
-            yield return new WaitForSeconds(1f);
-
+            // Delay start of trial if this is not the first trial of the task
+            if (currentTrialNumber != -1)
+            {
+                yield return new WaitForSeconds(1f);
+            }
+            
             // Show simulation and begin timer for the trial
             ShowSimulation = true;
             _timer.StartTimer();


### PR DESCRIPTION
This delay is now only added between trials and not for the first trial.