### PR TITLE
Check passthrough for null before enabling and disabling

### DIFF
--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Visuals/PassthroughHandler.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Visuals/PassthroughHandler.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-namespace NanoverImd.Subtle_Game.Visuals
+namespace NanoverIMD.Subtle_Game.UI.Visuals
 {
     public class PassthroughHandler : MonoBehaviour
     {
@@ -8,11 +8,13 @@ namespace NanoverImd.Subtle_Game.Visuals
 
         private void OnEnable()
         {
+            if (passthroughLayer == null) return;
             passthroughLayer.enabled = true;
         }
     
         private void OnDisable()
         {
+            if (passthroughLayer == null) return;
             passthroughLayer.enabled = false;
         }
     }


### PR DESCRIPTION
This stops the null reference exception error happening when you exit the game.