### PR TITLE
Check for stable knot

### DIFF
--- a/Client/task_knot_tying.py
+++ b/Client/task_knot_tying.py
@@ -31,7 +31,8 @@ class KnotTyingTask(Task):
                                                resids=self.residue_ids,
                                                atom_positions=self.client.latest_frame.particle_positions)
 
-        # Keeping checking if chain is knotted
+        # Keeping checking if the chain is knotted
+        consecutive_knotted_frames = 0
         while True:
 
             # Check that the particle positions exist in the latest frame
@@ -39,10 +40,15 @@ class KnotTyingTask(Task):
                 print("No particle positions found, waiting for 1/30 seconds before trying again.")
                 time.sleep(standard_rate)
 
-            self.knot_pull_client.check_if_chain_is_knotted(
-                atom_positions=self.client.latest_frame.particle_positions)
+            self.knot_pull_client.check_if_chain_is_knotted(atom_positions=self.client.latest_frame.particle_positions)
 
             if self.knot_pull_client.is_currently_knotted:
+                consecutive_knotted_frames += 1  # Increment the counter
+            else:
+                consecutive_knotted_frames = 0  # Reset the counter
+
+            # Check if the condition has been true for 30 consecutive iterations
+            if consecutive_knotted_frames >= 30:
                 self.timestamp_end = datetime.now()
                 break
 


### PR DESCRIPTION
The code now checks that the 17-ala remains knotted over 30 consecutive frames. This seems to work well, but the number 30 was chosen arbitrarily, so maybe this should change in the future.

In terms of the UI, nothing has changed for the moment. Luis suggested that this is probably best, but we can see if something needs to be implemented to let the know when the code starts detecting a knot. Currently the player is not notified when the first knot is detected, the simulation only changes colour once the stable knot is detected, and then the confetti comes a little after that.