### PR TITLE
Fix trials back panel and score icon

### DIFF
--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/Data Collection/TrialAnswerSubmission.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/Data Collection/TrialAnswerSubmission.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using Nanover.Visualisation.Components.Input;
 using NanoverImd.Subtle_Game.Simulation;
+using NanoverIMD.Subtle_Game.UI.Visuals;
 using UnityEngine;
 
 namespace NanoverImd.Subtle_Game.Data_Collection

--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/SubtleGameManager.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/SubtleGameManager.cs
@@ -7,6 +7,7 @@ using NanoverImd.Subtle_Game.Canvas;
 using NanoverImd.Subtle_Game.Data_Collection;
 using NanoverImd.Subtle_Game.Interaction;
 using NanoverIMD.Subtle_Game.UI.Canvas;
+using NanoverIMD.Subtle_Game.UI.Visuals;
 using NanoverImd.Subtle_Game.Visuals;
 using UnityEngine;
 using UnityEngine.Serialization;

--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Visuals/TrialAnswerPopupManager.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Visuals/TrialAnswerPopupManager.cs
@@ -1,101 +1,129 @@
 using System.Collections;
-using System.Collections.Generic;
-using NanoverImd.Selection;
 using UnityEngine;
 
-public class TrialAnswerPopupManager : MonoBehaviour
+namespace NanoverIMD.Subtle_Game.UI.Visuals
 {
-    [SerializeField] private float animationDurationIn = 0.4f;
-    [SerializeField] private float animationDurationStay = 0.2f;
-    [SerializeField] private float animationDurationOut = 0.2f;
-
-    private float animationDisplacementUp = 0.15f;
-
-    private SpriteRenderer spriteRenderer;
-
-    private void Awake()
+    public class TrialAnswerPopupManager : MonoBehaviour
     {
-        spriteRenderer = GetComponent<SpriteRenderer>();
-        if (spriteRenderer == null)
+        [SerializeField] private float animationDurationIn = 0.4f;
+        [SerializeField] private float animationDurationStay = 0.2f;
+        [SerializeField] private float animationDurationOut = 0.2f;
+
+        private float animationDisplacementUp = 0.15f;
+
+        private SpriteRenderer spriteRenderer;
+        
+        [SerializeField] private Transform vrHeadset;
+
+        private void Awake()
         {
-            Debug.Log("No sprite renderer component attatched, animation will fail");
-        }
-    }
-
-    // <summary>
-    // Displays the right icon and animate it
-    // </summary>
-    public void Pop(string _answer)
-    {
-        this.gameObject.SetActive(true);
-
-        foreach (Transform child in this.gameObject.transform)
-        {
-            child.gameObject.SetActive(false);
-
-            if (child.gameObject.name == _answer)
+            spriteRenderer = GetComponent<SpriteRenderer>();
+            if (spriteRenderer == null)
             {
-                spriteRenderer.sprite = child.GetComponent<SpriteRenderer>().sprite;
+                Debug.Log("No sprite renderer component attached, animation will fail");
             }
         }
 
-        StartCoroutine(Animate());
-    }
-
-    // <summary>
-    // Coroutine that animates the pop up
-    // </summary> 
-    private IEnumerator Animate()
-    {
-        float elapsed = 0.0f;
-        Vector3 targetPosition = transform.position + (Vector3.up * animationDisplacementUp);
-        Vector3 initialPosition = transform.position;
-
-        while (elapsed < animationDurationIn)
+        // <summary>
+        // Displays the correct icon and animate it.
+        // </summary>
+        public void Pop(string _answer)
         {
-            float alpha = Mathf.Lerp(0.0f, 1.0f, elapsed / animationDurationIn);
-            Color newColor = spriteRenderer.color;
-            newColor.a = alpha;
-            spriteRenderer.color = newColor;
+            gameObject.SetActive(true);
 
-            transform.position = Vector3.Lerp(initialPosition, targetPosition, elapsed / animationDurationIn);
+            foreach (Transform child in gameObject.transform)
+            {
+                child.gameObject.SetActive(false);
 
-            elapsed += UnityEngine.Time.deltaTime;
-            yield return null;
-        }
-        elapsed = 0f;
+                if (child.gameObject.name == _answer)
+                {
+                    spriteRenderer.sprite = child.GetComponent<SpriteRenderer>().sprite;
+                }
+            }
 
-        while (elapsed < animationDurationStay)
-        {
-            elapsed += UnityEngine.Time.deltaTime;
-            yield return null;
-        }
-        elapsed = 0f;
-
-        while (elapsed < animationDurationOut)
-        {
-            float alpha = Mathf.Lerp(1.0f, 0.0f, elapsed / animationDurationIn);
-            Color newColor = spriteRenderer.color;
-            newColor.a = alpha;
-            spriteRenderer.color = newColor;
-
-            elapsed += UnityEngine.Time.deltaTime;
-            yield return null;
+            StartCoroutine(Animate());
         }
 
-        gameObject.SetActive(false);
-    }
+        // <summary>
+        // Coroutine that animates the pop up.
+        // </summary> 
+        private IEnumerator Animate()
+        {
+            float elapsed = 0.0f;
+            Vector3 targetPosition = transform.position + (Vector3.up * animationDisplacementUp);
+            Vector3 initialPosition = transform.position;
+            
+            SetRotation();
 
-    // <summary>
-    // place this object at the desired location (answered molecule)
-    // </summary>
-    public void PlaceAt(Vector3 location)
-    {
-        this.gameObject.transform.position = location;
-    }
+            while (elapsed < animationDurationIn)
+            {
+                float alpha = Mathf.Lerp(0.0f, 1.0f, elapsed / animationDurationIn);
+                Color newColor = spriteRenderer.color;
+                newColor.a = alpha;
+                spriteRenderer.color = newColor;
 
-    public void Hide()
-    {
-        gameObject.SetActive(false);
+                transform.position = Vector3.Lerp(initialPosition, targetPosition, elapsed / animationDurationIn);
+
+                elapsed += Time.deltaTime;
+                yield return null;
+            }
+            elapsed = 0f;
+
+            while (elapsed < animationDurationStay)
+            {
+                elapsed += Time.deltaTime;
+                yield return null;
+            }
+            elapsed = 0f;
+
+            while (elapsed < animationDurationOut)
+            {
+                float alpha = Mathf.Lerp(1.0f, 0.0f, elapsed / animationDurationIn);
+                Color newColor = spriteRenderer.color;
+                newColor.a = alpha;
+                spriteRenderer.color = newColor;
+
+                elapsed += Time.deltaTime;
+                yield return null;
+            }
+
+            gameObject.SetActive(false);
+        }
+
+        // <summary>
+        // place this object at the desired location (answered molecule).
+        // </summary>
+        public void PlaceAt(Vector3 location)
+        {
+            gameObject.transform.position = location;
+        }
+        
+        // <summary>
+        // Sets the rotation of the pop up (facing the player, perpendicular to the floor).
+        // </summary>
+        private void SetRotation()
+        {
+            if (vrHeadset != null)
+            {
+                // Calculate the direction from the game object to the VR headset
+                var directionToHeadset = vrHeadset.position - transform.position;
+
+                // Ensure the direction is not zero (to avoid division by zero)
+                if (directionToHeadset == Vector3.zero) return;
+                
+                // Calculate the rotation needed to face the headset
+                Quaternion rotationToHeadset = Quaternion.LookRotation(directionToHeadset);
+
+                // Flip the rotation 180 degrees around the y-axis
+                rotationToHeadset *= Quaternion.Euler(0f, 180f, 0f);
+
+                // Apply the rotation to the game object
+                transform.rotation = Quaternion.Euler(0f, rotationToHeadset.eulerAngles.y, 0f);
+            }
+            else
+            {
+                Debug.LogWarning("VR headset reference is null. Make sure to assign the VR headset transform.");
+            }
+        }
     }
 }

--- a/Client/vr-client/Assets/Scenes/Main.unity
+++ b/Client/vr-client/Assets/Scenes/Main.unity
@@ -15454,6 +15454,7 @@ MonoBehaviour:
   animationDurationIn: 0.4
   animationDurationStay: 0.2
   animationDurationOut: 0.2
+  vrHeadset: {fileID: 4948775120161647665}
 --- !u!212 &1381040380
 SpriteRenderer:
   m_ObjectHideFlags: 0

--- a/Client/vr-client/Assets/Scenes/Main.unity
+++ b/Client/vr-client/Assets/Scenes/Main.unity
@@ -1372,10 +1372,7 @@ PrefabInstance:
     - {fileID: 656991192480398139, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
     - {fileID: 3246337340863214673, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
     m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 6406907961171276735, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
 --- !u!4 &67149927 stripped
 Transform:
@@ -16594,10 +16591,10 @@ MonoBehaviour:
   m_GameObject: {fileID: 1490121851}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8a4cf7eefff14154b9111fca6c42fd24, type: 3}
+  m_Script: {fileID: 11500000, guid: 3644143fcb4450b41b82bb139ef030b7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  frameSource: {fileID: 1265723032}
+  gameObjectWithDesiredPosition: {fileID: 829249466}
 --- !u!1001 &1491398896
 PrefabInstance:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
The instructions panel on the back face of the sim box for the trials is now placed at the correct position (on the back panel, facing the player at approx. eye level). The animation pop up has also been fixed, it now faces the player. 