### PR TITLE
Fix UI flashing up

### DIFF
--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Canvas/TaskInstructionsManager.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Canvas/TaskInstructionsManager.cs
@@ -5,7 +5,6 @@ using NanoverImd.Subtle_Game.Data_Collection;
 using NanoverImd.Subtle_Game.Interaction;
 using NanoverImd.Subtle_Game.UI.Simulation;
 using UnityEngine;
-using UnityEngine.Serialization;
 
 namespace NanoverIMD.Subtle_Game.UI.Canvas
 {
@@ -69,10 +68,10 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
         /// <summary>
         /// The Trial Icon Manager.
         /// </summary>
-        [FormerlySerializedAs("trialIconManager")] [SerializeField] private TrialManager trialProgressManager;
+        [SerializeField] private TrialManager trialProgressManager;
 
         // <summary>
-        // The gameobject group to set the visibility of the progress
+        // The game object group to set the visibility of the progress
         // <summary>
         [SerializeField] private GameObject trialsProgressGroup;
 
@@ -118,50 +117,51 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
         {
             if (_subtleGameManager is null) return;
 
-            // to overcome race conditions, we position and setup the input instructions constantly
-            SetupPanelPosition();
+            // To overcome race conditions, we position and setup the input instructions constantly
+            PlacePanelOnRightFaceOfSimBox();
             SetupInputInstructions();
-            
-            IEnumerator DelayedSetActive(GameObject obj, bool value, float seconds)
-            {
-                yield return new WaitForSeconds(seconds);
-                obj.SetActive(value);
-            }
-            
-            // activate the instructions panel when the simulation starts (and the panel is not active)
+
+            // Check the following: the sim is showing, the panel is not already active, and the task has changed
             if (_subtleGameManager.ShowSimulation && _panel.activeSelf==false)
             {
-                // It takes a few frames for the box to be correctly positioned, so don't flash the panel up until
-                // it's where it should be
-                StartCoroutine(DelayedSetActive(_panel, true, 0.1f));
+                // Position panel
+                PlacePanelOnRightFaceOfSimBox();
                 SetupLayout();
+                
+                // It takes a few frames for the box to be correctly positioned, so enable panel with slight delay
+                StartCoroutine(DelayedSetActive(_panel, true, 0.1f));
             }
 
             var playerInTrials = _subtleGameManager.CurrentTaskType == SubtleGameManager.TaskTypeVal.Trials;
 
-            // Do nothing if the simulation is still showing or the panel is active or the player is not currently in
-            // the trials task
+            // Do nothing if: the simulation is still showing // the panel is active // the player is in the trials
             if (_subtleGameManager.ShowSimulation || !_panel.activeSelf || playerInTrials) return;
             
-            // HERE: The simulation is not showing, the panel is active and the player is not in the trials...
-            trialProgressManager.ResetTrialsTask(); // reset trials
-            _panel.SetActive(false); // hide the instructions panel
+            // Reset trials and hide the instructions panel
+            trialProgressManager.ResetTrialsTask();
+            _panel.SetActive(false);
         }
-
+        
         /// <summary>
-        /// Positions the panel and activate the proper elements
+        /// Enable a game object with a slight delay.
+        /// </summary>
+        private IEnumerator DelayedSetActive(GameObject obj, bool value, float seconds)
+        {
+            yield return new WaitForSeconds(seconds);
+            obj.SetActive(value);
+        }
+        
+        /// <summary>
+        /// Call the functions to position the panel and activate the required elements.
         /// </summary>
         private void SetupLayout()
         {
-            SetupPanelPosition();
-
             SetupTaskElements();
-
             SetupInputInstructions();
         }
 
         // <summary>
-        //  Activate the proper elements for each task
+        //  Activate the required elements for the given task.
         // </summary>
         private void SetupTaskElements()
         {
@@ -199,7 +199,7 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
         }
 
         // <summary>
-        // Activate the corresponding interaction instructions for the given task and input method
+        // Activate the corresponding interaction instructions for the given task and interaction mode.
         // </summary>
         private void SetupInputInstructions()
         {
@@ -215,10 +215,9 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
         }
         
         /// <summary>
-        /// Place the in-task instructions at right face of the simulation box
-        /// depends on the simulation box
+        /// Place the in-task instructions at right face of the simulation box.
         /// </summary>
-        private void SetupPanelPosition()
+        private void PlacePanelOnRightFaceOfSimBox()
         {
             gameObject.transform.position = centerRightFace.transform.position;
             gameObject.transform.rotation = centerRightFace.transform.rotation;

--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Canvas/TaskInstructionsManager.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Canvas/TaskInstructionsManager.cs
@@ -218,23 +218,6 @@ namespace NanoverImd.Subtle_Game.Canvas
         }
         
         /// <summary>
-        /// Enables the correct instructions based on the current interaction mode.
-        /// </summary>
-        private void UpdateInteractionInstructions()
-        {
-            if (pinchGrab.UseControllers)
-            {
-                inputHandInstructions.SetActive(false);
-                inputControllerInstructions.SetActive(true);
-            }
-            else
-            {
-                inputHandInstructions.SetActive(true);
-                inputControllerInstructions.SetActive(false); 
-            }
-        }
-
-        /// <summary>
         /// Place the in-task instructions at right face of the simulation box
         /// depends on the simulation box
         /// </summary>
@@ -242,28 +225,6 @@ namespace NanoverImd.Subtle_Game.Canvas
         {
             gameObject.transform.position = centerRightFace.transform.position;
             gameObject.transform.rotation = centerRightFace.transform.rotation;
-        }
-
-        /// <summary>
-        /// Enables the relevant task-related elements on the instructions canvas.
-        /// </summary>
-        private void EnableTrialsRelatedGameObjects(bool isTrials)
-        {
-            timer.SetActive(isTrials);
-            trialProgressManager.gameObject.SetActive(isTrials);
-            trialProgressManager.ResetTrialsTask();
-        }
-
-        // <summary>
-        //  Activate or deactivate all childs
-        //  True: activate them. False: deactivate them
-        // </summary>
-        private void ShowOrHideInstructionsCanvas(bool showCanvas)
-        {
-            foreach (Transform child in transform)
-            {
-                child.gameObject.SetActive(showCanvas);
-            }
         }
 
         private void HandlePlayerIsSelectingAnswer(bool playerIsSelectingAnswer)

--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Canvas/TaskInstructionsManager.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Canvas/TaskInstructionsManager.cs
@@ -1,11 +1,13 @@
 ﻿using System.Collections;
-using NanoverImd.Subtle_Game.Interaction;
+using NanoverImd.Subtle_Game;
+using NanoverImd.Subtle_Game.Canvas;
 using NanoverImd.Subtle_Game.Data_Collection;
+using NanoverImd.Subtle_Game.Interaction;
 using NanoverImd.Subtle_Game.UI.Simulation;
 using UnityEngine;
 using UnityEngine.Serialization;
 
-namespace NanoverImd.Subtle_Game.Canvas
+namespace NanoverIMD.Subtle_Game.UI.Canvas
 {
     public class TaskInstructionsManager : MonoBehaviour
     {
@@ -28,8 +30,7 @@ namespace NanoverImd.Subtle_Game.Canvas
         /// Game object with the instructions on how interact with molecules using controllers.
         /// </summary>
         [SerializeField] private GameObject inputBothInputsInstructions;
-
-
+        
         /// <summary>
         /// Game object with the instructions on knot tie instructions.
         /// </summary>
@@ -86,10 +87,6 @@ namespace NanoverImd.Subtle_Game.Canvas
         // Panel game object containing all of the instructions elements
         // </summary>
         private GameObject _panel;
-
-        private bool _playerWasInTrials;
-
-        private SubtleGameManager.TaskTypeVal _previousTask;
 
         [SerializeField] private GameObject selectingAnswerForTrialsInstructions;
 

--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Simulation/BackFace.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Simulation/BackFace.cs
@@ -1,4 +1,5 @@
-﻿using Nanover.Visualisation;
+﻿using System;
+using Nanover.Visualisation;
 using UnityEngine;
 
 namespace NanoverIMD.Subtle_Game.UI.Simulation
@@ -15,6 +16,10 @@ namespace NanoverIMD.Subtle_Game.UI.Simulation
         {
             // Update position of current game object
             if (frameSource.CurrentFrame is not { BoxVectors: { } box }) return;
+            
+            // Don't reposition if the box lengths are zero
+            if (Math.Abs(box.axesMagnitudes.x) <= 0.001f) return;
+            
             transform.localPosition = new Vector3(
                 box.axesMagnitudes.x * 0.5f,
                 box.axesMagnitudes.x * 0.25f,

--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Simulation/CenterRightFace.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Simulation/CenterRightFace.cs
@@ -1,3 +1,4 @@
+using System;
 using Nanover.Visualisation;
 using UnityEngine;
 
@@ -15,6 +16,11 @@ namespace NanoverImd.Subtle_Game.UI.Simulation
         {
             // Update position of current game object
             if (frameSource.CurrentFrame is not { BoxVectors: { } box }) return;
+            
+            // Don't reposition if the box lengths are zero
+            if (Math.Abs(box.axesMagnitudes.x) <= 0.001f) return;
+            
+            // Place the current game object at the center of the right hand side face of the sim box
             transform.localPosition = new Vector3(
                 box.axesMagnitudes.x * 1.0f,
                 box.axesMagnitudes.x * 0.5f,


### PR DESCRIPTION
There was a problem where the task instructions were flashing up at the center of the box before being positioned in the correct place. We now add a slight delay to the enabling of the task instructions, to give time for the sim box to be put in the correct position. We also now check that the box length (along the x-axis) is not zero before reposition the game objects that are placed at the right hand face and back face of the sim box (these game objects are used to position the instructions panels).