### PR TITLE
Refactor to remove reference to "client" module

### DIFF
--- a/Client/task_knot_tying.py
+++ b/Client/task_knot_tying.py
@@ -1,7 +1,7 @@
 from datetime import datetime
-from Client.task import Task
+from task import Task
 from nanover.app import NanoverImdClient
-from Client.knot_pull_client import KnotPullClient
+from knot_pull_client import KnotPullClient
 import time
 from standardised_values import *
 

--- a/Client/task_nanotube.py
+++ b/Client/task_nanotube.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from Client.task import Task
+from task import Task
 from nanover.app import NanoverImdClient
 import numpy as np
 from scipy.spatial import Delaunay

--- a/Client/task_sandbox.py
+++ b/Client/task_sandbox.py
@@ -1,4 +1,4 @@
-from Client.task import Task
+from task import Task
 from nanover.app import NanoverImdClient
 import time
 

--- a/Client/task_trials.py
+++ b/Client/task_trials.py
@@ -1,8 +1,8 @@
-from Client.task import Task
+from task import Task
 from nanover.app import NanoverImdClient
 from additional_functions import write_to_shared_state, remove_puppeteer_key_from_shared_state
 from standardised_values import *
-from Client.task_trials_functions import get_order_of_simulations
+from task_trials_functions import get_order_of_simulations
 
 
 class TrialsTask(Task):

--- a/Client/task_trials_observer.py
+++ b/Client/task_trials_observer.py
@@ -1,8 +1,8 @@
-from Client.task import Task
+from task import Task
 from nanover.app import NanoverImdClient
 from additional_functions import write_to_shared_state, remove_puppeteer_key_from_shared_state
 from standardised_values import *
-from Client.task_trials_functions import get_order_of_simulations
+from task_trials_functions import get_order_of_simulations
 
 
 class TrialsObserverTask(Task):


### PR DESCRIPTION
Use direct imports of classes. This will allow us to run the puppeteering client from the command line.