### PR TITLE
Show/hide the avatars based on whether the simulation box is visible

### DIFF
--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/Multiplayer/AvatarController.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/Multiplayer/AvatarController.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+
+namespace NanoverIMD.Subtle_Game.Multiplayer
+{
+    public class AvatarController : MonoBehaviour
+    {
+        /// <summary>
+        /// The parent game object of the avatars.
+        /// </summary>
+        [SerializeField] private GameObject avatarParentObject;
+        
+        /// <summary>
+        /// Show or hide the avatars. This is done by enabling or disabling their parent game object.
+        /// </summary>
+        public void ToggleAvatars(bool isEnabled)
+        {
+            avatarParentObject?.SetActive(isEnabled);
+        }
+    }
+}

--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/Multiplayer/AvatarController.cs.meta
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/Multiplayer/AvatarController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5e4fa0213f5107546b8d20c4546e8754
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/Multiplayer/NanoverImdAvatarManager.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/Multiplayer/NanoverImdAvatarManager.cs
@@ -6,6 +6,7 @@ using Nanover.Frontend.XR;
 using Nanover.Grpc.Multiplayer;
 using NanoverIMD.Subtle_Game.Multiplayer;
 using UnityEngine;
+using UnityEngine.Serialization;
 using UnityEngine.XR;
 
 namespace NanoverImd
@@ -24,6 +25,11 @@ namespace NanoverImd
 
         [SerializeField]
         private AvatarModel controllerPrefab;
+        
+        /// <summary>
+        /// The parent game object of the avatars.
+        /// </summary>
+        [SerializeField] private Transform avatarParentObject;
 #pragma warning restore 0649
         
         private IndexedPool<AvatarModel> headsetObjects;
@@ -41,13 +47,13 @@ namespace NanoverImd
         private void OnEnable()
         {
             headsetObjects = new IndexedPool<AvatarModel>(
-                () => Instantiate(headsetPrefab),
+                () => Instantiate(headsetPrefab, avatarParentObject),
                 transform => transform.gameObject.SetActive(true),
                 transform => transform.gameObject.SetActive(false)
             );
 
             controllerObjects = new IndexedPool<AvatarModel>(
-                () => Instantiate(controllerPrefab),
+                () => Instantiate(controllerPrefab, avatarParentObject),
                 transform => transform.gameObject.SetActive(true),
                 transform => transform.gameObject.SetActive(false)
             );

--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/SubtleGameManager.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/SubtleGameManager.cs
@@ -7,6 +7,7 @@ using NanoverImd.Subtle_Game.Canvas;
 using NanoverImd.Subtle_Game.Data_Collection;
 using NanoverIMD.Subtle_Game.Data_Collection;
 using NanoverImd.Subtle_Game.Interaction;
+using NanoverIMD.Subtle_Game.Multiplayer;
 using NanoverIMD.Subtle_Game.UI.Canvas;
 using NanoverIMD.Subtle_Game.UI.Visuals;
 using NanoverImd.Subtle_Game.Visuals;
@@ -53,8 +54,9 @@ namespace NanoverImd.Subtle_Game
                 set
                 {
                     _showSimulation = value;
-                    simulationSpace.SetActive(_showSimulation);
-                    EnableInteractions = _showSimulation;
+                    simulationSpace.SetActive(_showSimulation); // show/hide simulation box
+                    avatarController.ToggleAvatars(_showSimulation); // show/hide avatars
+                    EnableInteractions = _showSimulation; // toggle script for user interactions
                 }
             }
 
@@ -229,6 +231,11 @@ namespace NanoverImd.Subtle_Game
         #endregion
         
         #region Trials
+        
+        /// <summary>
+        /// The Avatar Controller, which shows/hides the avatars during the Trials tasks.
+        /// </summary>
+        [SerializeField] private AvatarController avatarController;
         
         private TrialsTimer _timer;
         [FormerlySerializedAs("trialIconManager")] [SerializeField] private TrialManager trialManager;

--- a/Client/vr-client/Assets/Scenes/Main.unity
+++ b/Client/vr-client/Assets/Scenes/Main.unity
@@ -5198,6 +5198,37 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   textMeshPro: {fileID: 1694557276}
+--- !u!1 &390955719
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 390955720}
+  m_Layer: 0
+  m_Name: Avatar parent
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &390955720
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 390955719}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 758418883}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &394664563 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 6896215808809296414, guid: 4be29d3cb086d8540a6175a41e05b7f4, type: 3}
@@ -9391,6 +9422,7 @@ GameObject:
   m_Component:
   - component: {fileID: 758418883}
   - component: {fileID: 758418884}
+  - component: {fileID: 758418885}
   m_Layer: 0
   m_Name: Multiplayer
   m_TagString: Untagged
@@ -9412,6 +9444,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1925843024}
+  - {fileID: 390955720}
   m_Father: {fileID: 1364228085}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &758418884
@@ -9428,6 +9461,19 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   simulation: {fileID: 1265723033}
   avatars: {fileID: 1925843025}
+--- !u!114 &758418885
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 758418882}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5e4fa0213f5107546b8d20c4546e8754, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  avatarParentObject: {fileID: 390955719}
 --- !u!1001 &760507463
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -19651,6 +19697,7 @@ MonoBehaviour:
   confetti: {fileID: 1233017830}
   isIntroToSection: 1
   interactionModalityHasChanged: 0
+  avatarController: {fileID: 758418885}
   trialManager: {fileID: 1245036777}
   trialAnswerSubmission: {fileID: 1364228087}
   currentTrialNumber: 0
@@ -25758,6 +25805,7 @@ MonoBehaviour:
   nanover: {fileID: 1265723033}
   headsetPrefab: {fileID: 493567020}
   controllerPrefab: {fileID: 486422601}
+  avatarParentObject: {fileID: 390955720}
 --- !u!1 &1950933474 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 3895664296461673764, guid: 4be29d3cb086d8540a6175a41e05b7f4, type: 3}


### PR DESCRIPTION
The avatars are now nested inside an "avatar parent" game object. This object is enabled and disabled at the same time as the simulation box. For the player, this means that the avatars are only visible if the simulation box is visible.

Previously, the avatars were visible when the player was in the intro and outro to the Trials task (since they are in the shared state at this point). We don't want to destroy the avatars completely, merely hide them for the player.