### PR TITLE
Disable interactions during Observer Trials

### DIFF
--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/SubtleGameManager.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/SubtleGameManager.cs
@@ -66,8 +66,12 @@ namespace NanoverImd.Subtle_Game
                 set
                 {
                     _enableInteractions = value;
-                    userInteraction.SetActive(_enableInteractions);
+                    
                     _userInteractionManager.UseControllers = CurrentInteractionModality == Modality.Controllers;
+                    
+                    // Toggle user interactions (always disabled during the observer trials tasks)
+                    userInteraction.SetActive(!TaskLists.ObserverTrialsTasks.Contains(CurrentTaskType) &&
+                                              _enableInteractions);
                 }
             }
 


### PR DESCRIPTION
When toggling the user interactions, check if the current task is an Observer task and if yes keep user interaction disabled, otherwise toggle as usual.