### PR TITLE
Fix local avatar reporting

### DIFF
--- a/Client/puppeteering_client.py
+++ b/Client/puppeteering_client.py
@@ -275,7 +275,7 @@ if __name__ == '__main__':
 
     # Create puppeteering client
     puppeteering_client = PuppeteeringClient(number_of_trial_repeats=number_of_repeats,
-                                             first_modality=MODALITY_CONTROLLERS)
+                                             first_modality=MODALITY_HANDS)
 
     # Start game
     puppeteering_client.run_game()

--- a/Client/puppeteering_client.py
+++ b/Client/puppeteering_client.py
@@ -275,7 +275,7 @@ if __name__ == '__main__':
 
     # Create puppeteering client
     puppeteering_client = PuppeteeringClient(number_of_trial_repeats=number_of_repeats,
-                                             first_modality=MODALITY_HANDS)
+                                             first_modality=MODALITY_CONTROLLERS)
 
     # Start game
     puppeteering_client.run_game()

--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/Multiplayer/NanoverImdAvatarManager.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/Multiplayer/NanoverImdAvatarManager.cs
@@ -124,6 +124,7 @@ namespace NanoverImd
             Transform leftHandControllerTransform;
             Transform rightHandControllerTransform;
             
+            // TODO: Make this nicer. Check this in update and only update the transforms if the mode has changed.
             if (AreControllersBeingTracked())
             {
                 leftHandControllerTransform = leftControllerPoke;

--- a/Client/vr-client/Assets/Scenes/Main.unity
+++ b/Client/vr-client/Assets/Scenes/Main.unity
@@ -25806,6 +25806,13 @@ MonoBehaviour:
   headsetPrefab: {fileID: 493567020}
   controllerPrefab: {fileID: 486422601}
   avatarParentObject: {fileID: 390955720}
+  leftControllerPoke: {fileID: 7416501715839334339}
+  rightControllerPoke: {fileID: 9116940136169035185}
+  leftIndexTip: {fileID: 4591869718317071806}
+  leftThumbTip: {fileID: 4887313454428485390}
+  rightIndexTip: {fileID: 4682591776209724542}
+  rightThumbTip: {fileID: 4595471348484302799}
+  headsetTransform: {fileID: 4948775120161647665}
 --- !u!1 &1950933474 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 3895664296461673764, guid: 4be29d3cb086d8540a6175a41e05b7f4, type: 3}


### PR DESCRIPTION
Fix the transforms of the local avatar (headset, left hand, right hand). These used to be obtained using `InputDeviceCharacteristics`. However, this was not reporting the correct transforms (possibly since the update to MetaSDKs? because it was working before). 

The avatar manager now uses the serialised transforms of the headset, left hand/controller, and right/hand controller. When the controllers are tracking, we use the "poke position" of the controllers; when the hands are tracking, we use the midpoint between the index finger and thumb tips. These are both the same as the interaction manager, meaning that the reported position of these objects is the same as the interaction origin when that object is interacting with the simulation.

I have tested this by recording a session and then replaying it in Subtle Game, and the recorded avatar is now correct relative to it's interactions and the sim box. Previously, the avatar was not in the correct place relative to it's interactions and the sim box.