### PR TITLE
Write knot state of 17-ala to shared state

### DIFF
--- a/Client/standardised_values.py
+++ b/Client/standardised_values.py
@@ -40,6 +40,7 @@ KEY_ORDER_OF_TASKS = 'order-of-tasks'
 KEY_SIM_COUNTER = 'system-simulation-counter'
 KEY_CURRENT_TASK = 'current-task'
 KEY_TASK_STATUS = 'task-status'
+KEY_TASK_COMMENT = 'task-comment'
 KEY_TRIALS_SIMS = 'trials-simulations'
 KEY_NUMBER_OF_TRIALS = 'number-of-trials'
 KEY_NUMBER_OF_TRIAL_REPEATS = 'number-of-trial-repeats'
@@ -64,6 +65,9 @@ FALSE = 'False'
 # Interaction modality
 MODALITY_HANDS = 'hands'
 MODALITY_CONTROLLERS = 'controllers'
+# Task comments
+CHAIN_KNOTTED = 'knotted'
+CHAIN_UNKNOTTED = 'unknotted'
 
 # ---------------- #
 # PLAYER
@@ -101,4 +105,4 @@ SHARED_STATE_KEYS_AND_VALS = {
 
 KEYS_WITH_UNRESTRICTED_VALS = [KEY_TASK_COMPLETION_TIME, KEY_SIMULATION_NAME, KEY_SIMULATION_SERVER_INDEX,
                                KEY_TRIALS_SIMS, KEY_NUMBER_OF_TRIALS, KEY_NUMBER_OF_TRIAL_REPEATS, KEY_USERNAME,
-                               KEY_SIM_COUNTER, KEY_START_TIME, KEY_END_TIME]
+                               KEY_SIM_COUNTER, KEY_START_TIME, KEY_END_TIME, KEY_TASK_COMMENT]

--- a/Client/task.py
+++ b/Client/task.py
@@ -161,6 +161,7 @@ class Task:
 
         try:
             remove_puppeteer_key_from_shared_state(client=self.client, key=KEY_TASK_COMPLETION_TIME)
+            remove_puppeteer_key_from_shared_state(client=self.client, key=KEY_TASK_COMMENT)
 
         except KeyError:
             return

--- a/Client/task_knot_tying.py
+++ b/Client/task_knot_tying.py
@@ -4,6 +4,7 @@ from nanover.app import NanoverImdClient
 from knot_pull_client import KnotPullClient
 import time
 from standardised_values import *
+from additional_functions import write_to_shared_state
 
 
 class KnotTyingTask(Task):
@@ -33,6 +34,8 @@ class KnotTyingTask(Task):
 
         # Keeping checking if the chain is knotted
         consecutive_knotted_frames = 0
+        write_to_shared_state(client=self.client, key=KEY_TASK_COMMENT, value=CHAIN_UNKNOTTED)
+
         while True:
 
             # Check that the particle positions exist in the latest frame
@@ -44,8 +47,10 @@ class KnotTyingTask(Task):
 
             if self.knot_pull_client.is_currently_knotted:
                 consecutive_knotted_frames += 1  # Increment the counter
+                write_to_shared_state(client=self.client, key=KEY_TASK_COMMENT, value=CHAIN_KNOTTED)
             else:
                 consecutive_knotted_frames = 0  # Reset the counter
+                write_to_shared_state(client=self.client, key=KEY_TASK_COMMENT, value=CHAIN_UNKNOTTED)
 
             # Check if the condition has been true for 30 consecutive iterations
             if consecutive_knotted_frames >= 60:


### PR DESCRIPTION
Update the current state of the 17-ala (unknotted/knotted) in the shared state. This will help us see how difficult participants find it to make a stable knot.