### PR TITLE
Move nanotube-methane sim in sim box

### DIFF
--- a/Inputs/nanotube-methane.xml
+++ b/Inputs/nanotube-methane.xml
@@ -136,71 +136,71 @@ _atom_site.auth_comp_id
 _atom_site.auth_asym_id
 _atom_site.auth_atom_id
 _atom_site.pdbx_PDB_model_num
-HETATM      1 C   C1   . CNT  A ?     1 .    17.7381    18.3921    17.9729  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A   C1     1
-HETATM      2 C   C2   . CNT  A ?     1 .    17.5501    19.7199    17.8243  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A   C2     1
-HETATM      3 C   C3   . CNT  A ?     1 .    18.1996    20.4895    18.6851  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A   C3     1
-HETATM      4 C   C4   . CNT  A ?     1 .    17.4620    21.2519    19.4629  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A   C4     1
-HETATM      5 C   C5   . CNT  A ?     1 .    16.1244    21.2874    19.4445  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A   C5     1
-HETATM      6 C   C6   . CNT  A ?     1 .    15.4387    20.8339    20.5010  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A   C6     1
-HETATM      7 C   C7   . CNT  A ?     1 .    16.2847    20.3842    21.4371  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A   C7     1
-HETATM      8 C   C8   . CNT  A ?     1 .    16.4012    19.0504    21.5477  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A   C8     1
-HETATM      9 C   C9   . CNT  A ?     1 .    15.7441    18.2695    20.7565  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A   C9     1
-HETATM     10 C   C10  . CNT  A ?     1 .    16.3890    17.3681    20.0117  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C10     1
-HETATM     11 C   C11  . CNT  A ?     1 .    17.7537    17.4938    20.0790  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C11     1
-HETATM     12 C   C12  . CNT  A ?     1 .    18.3940    18.0386    19.0578  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C12     1
-HETATM     13 C   C13  . CNT  A ?     1 .    19.4068    18.7773    19.4372  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C13     1
-HETATM     14 C   C14  . CNT  A ?     1 .    19.3518    20.0718    19.1672  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C14     1
-HETATM     15 C   C15  . CNT  A ?     1 .    19.9719    20.8660    20.0176  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C15     1
-HETATM     16 C   C16  . CNT  A ?     1 .    19.2967    21.7312    20.7278  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C16     1
-HETATM     17 C   C17  . CNT  A ?     1 .    17.9938    21.6700    20.6268  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C17     1
-HETATM     18 C   C18  . CNT  A ?     1 .    17.4320    21.0789    21.6378  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C18     1
-HETATM     19 C   C19  . CNT  A ?     1 .    18.1055    20.7375    22.7181  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C19     1
-HETATM     20 C   C20  . CNT  A ?     1 .    18.1883    19.4354    22.9086  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C20     1
-HETATM     21 C   C21  . CNT  A ?     1 .    17.5318    18.5833    22.1122  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C21     1
-HETATM     22 C   C22  . CNT  A ?     1 .    18.2531    17.7714    21.3075  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C22     1
-HETATM     23 C   C23  . CNT  A ?     1 .    19.5366    17.8197    21.5080  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C23     1
-HETATM     24 C   C24  . CNT  A ?     1 .    20.1956    18.4047    20.4543  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C24     1
-HETATM     25 C   C25  . CNT  A ?     1 .    21.2548    19.1675    20.7038  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C25     1
-HETATM     26 C   C26  . CNT  A ?     1 .    21.1431    20.4590    20.4098  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C26     1
-HETATM     27 C   C27  . CNT  A ?     1 .    21.8988    21.2382    21.2055  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C27     1
-HETATM     28 C   C28  . CNT  A ?     1 .    21.1427    21.9856    22.0276  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C28     1
-HETATM     29 C   C29  . CNT  A ?     1 .    19.8137    22.0346    21.9445  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C29     1
-HETATM     30 C   C30  . CNT  A ?     1 .    19.2275    21.4090    22.9121  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C30     1
-HETATM     31 C   C31  . CNT  A ?     1 .    19.9215    21.0603    23.9618  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C31     1
-HETATM     32 C   C32  . CNT  A ?     1 .    19.9667    19.7288    24.2493  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C32     1
-HETATM     33 C   C33  . CNT  A ?     1 .    19.3162    18.8977    23.4332  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C33     1
-HETATM     34 C   C34  . CNT  A ?     1 .    20.0370    18.0089    22.7186  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C34     1
-HETATM     35 C   C35  . CNT  A ?     1 .    21.3824    18.1661    22.7562  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C35     1
-HETATM     36 C   C36  . CNT  A ?     1 .    21.9940    18.8240    21.7664  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C36     1
-HETATM     37 C   C37  . CNT  A ?     1 .    23.1394    19.5038    21.9606  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C37     1
-HETATM     38 C   C38  . CNT  A ?     1 .    23.0246    20.7746    21.6689  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C38     1
-HETATM     39 C   C39  . CNT  A ?     1 .    23.6918    21.5532    22.5512  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C39     1
-HETATM     40 C   C40  . CNT  A ?     1 .    23.0220    22.4280    23.3163  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C40     1
-HETATM     41 C   C41  . CNT  A ?     1 .    21.6746    22.2640    23.2341  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C41     1
-HETATM     42 C   C42  . CNT  A ?     1 .    21.0063    21.7442    24.2416  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C42     1
-HETATM     43 C   C43  . CNT  A ?     1 .    21.7031    21.3260    25.3127  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C43     1
-HETATM     44 C   C44  . CNT  A ?     1 .    21.6661    20.0163    25.6884  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C44     1
-HETATM     45 C   C45  . CNT  A ?     1 .    21.0670    19.2196    24.7822  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C45     1
-HETATM     46 C   C46  . CNT  A ?     1 .    21.8705    18.4275    23.9999  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C46     1
-HETATM     47 C   C47  . CNT  A ?     1 .    23.1501    18.6887    24.0867  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C47     1
-HETATM     48 C   C48  . CNT  A ?     1 .    23.8131    19.3104    23.1072  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C48     1
-HETATM     49 C   C49  . CNT  A ?     1 .    24.9423    19.9893    23.3989  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C49     1
-HETATM     50 C   C50  . CNT  A ?     1 .    24.9307    21.2327    22.9631  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C50     1
-HETATM     51 C   C51  . CNT  A ?     1 .    25.6045    22.1434    23.7450  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C51     1
-HETATM     52 C   C52  . CNT  A ?     1 .    24.8504    22.6380    24.7566  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C52     1
-HETATM     53 C   C53  . CNT  A ?     1 .    23.5127    22.5695    24.5847  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C53     1
-HETATM     54 C   C54  . CNT  A ?     1 .    22.8177    22.0053    25.5507  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C54     1
-HETATM     55 C   C55  . CNT  A ?     1 .    23.5173    21.6473    26.6556  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C55     1
-HETATM     56 C   C56  . CNT  A ?     1 .    23.4239    20.3386    27.0410  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C56     1
-HETATM     57 C   C57  . CNT  A ?     1 .    22.8073    19.4839    26.2187  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C57     1
-HETATM     58 C   C58  . CNT  A ?     1 .    23.6039    18.8666    25.3207  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C58     1
-HETATM     59 C   C59  . CNT  A ?     1 .    24.8798    19.0399    25.4777  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C59     1
-HETATM     60 C   C60  . CNT  A ?     1 .    25.5560    19.7465    24.5462  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C60     1
-HETATM     61 C   C61  . CNT  B ?     1 .    23.2582    27.6452    22.3933  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT B  C61     1
-HETATM     62 H   H1   . CNT  B ?     1 .    23.6141    27.8292    23.4233  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT B   H1     1
-HETATM     63 H   H2   . CNT  B ?     1 .    23.0312    26.5718    22.3915  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT B   H2     1
-HETATM     64 H   H3   . CNT  B ?     1 .    22.3490    28.2923    22.1756  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT B   H3     1
-HETATM     65 H   H4   . CNT  B ?     1 .    24.0885    27.8034    21.6373  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT B   H4     1
+HETATM      1 C   C1   . CNT  A ?     1 .    16.9460    15.7210    10.6080  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A   C1     1
+HETATM      2 C   C2   . CNT  A ?     1 .    16.7580    17.0490    10.4590  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A   C2     1
+HETATM      3 C   C3   . CNT  A ?     1 .    17.4080    17.8180    11.3200  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A   C3     1
+HETATM      4 C   C4   . CNT  A ?     1 .    16.6700    18.5810    12.0980  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A   C4     1
+HETATM      5 C   C5   . CNT  A ?     1 .    15.3320    18.6160    12.0800  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A   C5     1
+HETATM      6 C   C6   . CNT  A ?     1 .    14.6470    18.1630    13.1360  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A   C6     1
+HETATM      7 C   C7   . CNT  A ?     1 .    15.4930    17.7130    14.0720  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A   C7     1
+HETATM      8 C   C8   . CNT  A ?     1 .    15.6090    16.3790    14.1830  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A   C8     1
+HETATM      9 C   C9   . CNT  A ?     1 .    14.9520    15.5980    13.3910  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A   C9     1
+HETATM     10 C   C10  . CNT  A ?     1 .    15.5970    14.6970    12.6470  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C10     1
+HETATM     11 C   C11  . CNT  A ?     1 .    16.9620    14.8230    12.7140  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C11     1
+HETATM     12 C   C12  . CNT  A ?     1 .    17.6020    15.3680    11.6930  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C12     1
+HETATM     13 C   C13  . CNT  A ?     1 .    18.6150    16.1060    12.0720  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C13     1
+HETATM     14 C   C14  . CNT  A ?     1 .    18.5600    17.4010    11.8020  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C14     1
+HETATM     15 C   C15  . CNT  A ?     1 .    19.1800    18.1950    12.6530  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C15     1
+HETATM     16 C   C16  . CNT  A ?     1 .    18.5050    19.0600    13.3630  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C16     1
+HETATM     17 C   C17  . CNT  A ?     1 .    17.2020    18.9990    13.2620  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C17     1
+HETATM     18 C   C18  . CNT  A ?     1 .    16.6400    18.4080    14.2730  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C18     1
+HETATM     19 C   C19  . CNT  A ?     1 .    17.3130    18.0670    15.3530  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C19     1
+HETATM     20 C   C20  . CNT  A ?     1 .    17.3960    16.7640    15.5440  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C20     1
+HETATM     21 C   C21  . CNT  A ?     1 .    16.7400    15.9120    14.7470  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C21     1
+HETATM     22 C   C22  . CNT  A ?     1 .    17.4610    15.1000    13.9420  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C22     1
+HETATM     23 C   C23  . CNT  A ?     1 .    18.7450    15.1490    14.1430  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C23     1
+HETATM     24 C   C24  . CNT  A ?     1 .    19.4040    15.7340    13.0890  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C24     1
+HETATM     25 C   C25  . CNT  A ?     1 .    20.4630    16.4960    13.3390  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C25     1
+HETATM     26 C   C26  . CNT  A ?     1 .    20.3510    17.7880    13.0450  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C26     1
+HETATM     27 C   C27  . CNT  A ?     1 .    21.1070    18.5670    13.8400  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C27     1
+HETATM     28 C   C28  . CNT  A ?     1 .    20.3510    19.3150    14.6630  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C28     1
+HETATM     29 C   C29  . CNT  A ?     1 .    19.0220    19.3640    14.5790  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C29     1
+HETATM     30 C   C30  . CNT  A ?     1 .    18.4350    18.7380    15.5470  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C30     1
+HETATM     31 C   C31  . CNT  A ?     1 .    19.1290    18.3890    16.5970  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C31     1
+HETATM     32 C   C32  . CNT  A ?     1 .    19.1750    17.0580    16.8840  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C32     1
+HETATM     33 C   C33  . CNT  A ?     1 .    18.5240    16.2270    16.0680  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C33     1
+HETATM     34 C   C34  . CNT  A ?     1 .    19.2450    15.3380    15.3540  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C34     1
+HETATM     35 C   C35  . CNT  A ?     1 .    20.5900    15.4950    15.3910  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C35     1
+HETATM     36 C   C36  . CNT  A ?     1 .    21.2020    16.1530    14.4010  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C36     1
+HETATM     37 C   C37  . CNT  A ?     1 .    22.3470    16.8330    14.5960  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C37     1
+HETATM     38 C   C38  . CNT  A ?     1 .    22.2330    18.1040    14.3040  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C38     1
+HETATM     39 C   C39  . CNT  A ?     1 .    22.9000    18.8820    15.1860  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C39     1
+HETATM     40 C   C40  . CNT  A ?     1 .    22.2300    19.7570    15.9510  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C40     1
+HETATM     41 C   C41  . CNT  A ?     1 .    20.8830    19.5930    15.8690  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C41     1
+HETATM     42 C   C42  . CNT  A ?     1 .    20.2140    19.0730    16.8770  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C42     1
+HETATM     43 C   C43  . CNT  A ?     1 .    20.9110    18.6550    17.9480  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C43     1
+HETATM     44 C   C44  . CNT  A ?     1 .    20.8740    17.3450    18.3230  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C44     1
+HETATM     45 C   C45  . CNT  A ?     1 .    20.2750    16.5490    17.4170  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C45     1
+HETATM     46 C   C46  . CNT  A ?     1 .    21.0790    15.7560    16.6350  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C46     1
+HETATM     47 C   C47  . CNT  A ?     1 .    22.3580    16.0180    16.7220  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C47     1
+HETATM     48 C   C48  . CNT  A ?     1 .    23.0210    16.6390    15.7420  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C48     1
+HETATM     49 C   C49  . CNT  A ?     1 .    24.1500    17.3180    16.0340  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C49     1
+HETATM     50 C   C50  . CNT  A ?     1 .    24.1390    18.5620    15.5980  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C50     1
+HETATM     51 C   C51  . CNT  A ?     1 .    24.8130    19.4720    16.3800  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C51     1
+HETATM     52 C   C52  . CNT  A ?     1 .    24.0580    19.9670    17.3920  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C52     1
+HETATM     53 C   C53  . CNT  A ?     1 .    22.7210    19.8980    17.2200  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C53     1
+HETATM     54 C   C54  . CNT  A ?     1 .    22.0260    19.3340    18.1860  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C54     1
+HETATM     55 C   C55  . CNT  A ?     1 .    22.7250    18.9760    19.2910  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C55     1
+HETATM     56 C   C56  . CNT  A ?     1 .    22.6320    17.6680    19.6760  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C56     1
+HETATM     57 C   C57  . CNT  A ?     1 .    22.0150    16.8130    18.8540  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C57     1
+HETATM     58 C   C58  . CNT  A ?     1 .    22.8120    16.1960    17.9560  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C58     1
+HETATM     59 C   C59  . CNT  A ?     1 .    24.0880    16.3690    18.1130  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C59     1
+HETATM     60 C   C60  . CNT  A ?     1 .    24.7640    17.0760    17.1810  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT A  C60     1
+HETATM     61 C   C61  . CNT  B ?     1 .    22.4660    24.9740    15.0280  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT B  C61     1
+HETATM     62 H   H1   . CNT  B ?     1 .    22.8220    25.1580    16.0580  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT B   H1     1
+HETATM     63 H   H2   . CNT  B ?     1 .    22.2390    23.9010    15.0270  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT B   H2     1
+HETATM     64 H   H3   . CNT  B ?     1 .    21.5570    25.6210    14.8110  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT B   H3     1
+HETATM     65 H   H4   . CNT  B ?     1 .    23.2960    25.1320    14.2720  0.0  0.0  ?  ?  ?  ?  ?  .      1  CNT B   H4     1
 </pdbx>
 	<System openmmVersion="8.1.1" type="System" version="1">
 		
@@ -2427,236 +2427,235 @@ HETATM     65 H   H4   . CNT  B ?     1 .    24.0885    27.8034    21.6373  0.0 
 		
 			</Force>
 			
+		
+			<Force energy="-fx * x - fy * y - fz * z" forceGroup="31" name="CustomExternalForce" type="CustomExternalForce" version="1">
+				
+			
+				<PerParticleParameters>
+					
+				
+					<Parameter name="fx"/>
+					
+				
+					<Parameter name="fy"/>
+					
+				
+					<Parameter name="fz"/>
+					
+			
+				</PerParticleParameters>
+				
+			
+				<GlobalParameters/>
+				
+			
+				<Particles>
+					
+				
+					<Particle index="0" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="1" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="2" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="3" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="4" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="5" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="6" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="7" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="8" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="9" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="10" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="11" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="12" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="13" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="14" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="15" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="16" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="17" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="18" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="19" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="20" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="21" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="22" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="23" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="24" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="25" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="26" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="27" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="28" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="29" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="30" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="31" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="32" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="33" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="34" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="35" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="36" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="37" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="38" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="39" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="40" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="41" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="42" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="43" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="44" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="45" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="46" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="47" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="48" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="49" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="50" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="51" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="52" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="53" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="54" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="55" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="56" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="57" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="58" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="59" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="60" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="61" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="62" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="63" param1="0" param2="0" param3="0"/>
+					
+				
+					<Particle index="64" param1="0" param2="0" param3="0"/>
+					
+			
+				</Particles>
+				
+		
+			</Force>
+			
 	
 		</Forces>
 		
 
 	</System>
 	<Integrator constraintTolerance="1e-05" friction="4" randomSeed="0" stepSize=".0005" temperature="300" type="LangevinIntegrator" version="1"/>
-	<State openmmVersion="8.1.1" stepCount="5000" time="2.500000000000002" type="State" version="1">
-		
-	
-		<PeriodicBoxVectors>
-			
-		
-			<A x="4" y="0" z="0"/>
-			
-		
-			<B x="0" y="4" z="0"/>
-			
-		
-			<C x="0" y="0" z="4"/>
-			
-	
-		</PeriodicBoxVectors>
-		
-	
-		<Parameters c12="1" c6="0" cs="-25.5" mx="5" my="5" mz="5"/>
-		
-	
-		<Velocities>
-			
-		
-			<Velocity x=".7694471478462219" y="-.5331267714500427" z=".7134705781936646"/>
-			
-		
-			<Velocity x=".057968661189079285" y="-.3673322796821594" z="-.053344812244176865"/>
-			
-		
-			<Velocity x=".7080348134040833" y="-.20220758020877838" z=".058562733232975006"/>
-			
-		
-			<Velocity x="-.7183843851089478" y="-.08213341981172562" z=".48577871918678284"/>
-			
-		
-			<Velocity x=".12675365805625916" y="-.43938612937927246" z=".4362877309322357"/>
-			
-		
-			<Velocity x="-.4176383912563324" y="-1.0819599628448486" z=".5898053050041199"/>
-			
-		
-			<Velocity x=".8290274739265442" y=".9270970225334167" z="-.026371687650680542"/>
-			
-		
-			<Velocity x="-.4598793387413025" y=".11697643250226974" z=".12428240478038788"/>
-			
-		
-			<Velocity x="-.7491477131843567" y=".5241793990135193" z=".08227166533470154"/>
-			
-		
-			<Velocity x="-.012279277667403221" y="-.1994025558233261" z="-.4029894471168518"/>
-			
-		
-			<Velocity x="-.7501622438430786" y=".5087486505508423" z="-.03822749853134155"/>
-			
-		
-			<Velocity x=".6015867590904236" y="-.4357771575450897" z=".18834689259529114"/>
-			
-		
-			<Velocity x="-.4745767116546631" y=".5798400044441223" z=".5370634198188782"/>
-			
-		
-			<Velocity x="-.4904501736164093" y=".36433300375938416" z="-.5542455315589905"/>
-			
-		
-			<Velocity x=".5121238827705383" y="-.10588105767965317" z=".31499379873275757"/>
-			
-		
-			<Velocity x="-.04969625547528267" y=".39979270100593567" z="-.24299407005310059"/>
-			
-		
-			<Velocity x="-.5919164419174194" y="-.5948258638381958" z=".028720492497086525"/>
-			
-		
-			<Velocity x=".15851853787899017" y=".235122412443161" z="-.24730975925922394"/>
-			
-		
-			<Velocity x="-.19826625287532806" y=".7366315722465515" z="-.5740645527839661"/>
-			
-		
-			<Velocity x="-.3197029232978821" y="-.027033640071749687" z="-.10585079342126846"/>
-			
-		
-			<Velocity x="-.27563169598579407" y="-.7463781237602234" z="-1.0561354160308838"/>
-			
-		
-			<Velocity x="-.1462188959121704" y=".2040858119726181" z=".009113270789384842"/>
-			
-		
-			<Velocity x=".03607122227549553" y="-.425092488527298" z="-.16683173179626465"/>
-			
-		
-			<Velocity x=".252245157957077" y=".7029592990875244" z="-.4793158769607544"/>
-			
-		
-			<Velocity x=".095850870013237" y=".02724120393395424" z=".9132174253463745"/>
-			
-		
-			<Velocity x="-.30396023392677307" y=".4720337986946106" z=".3736112713813782"/>
-			
-		
-			<Velocity x=".4245201647281647" y="-.20743116736412048" z=".24105313420295715"/>
-			
-		
-			<Velocity x="-.6285996437072754" y="-.044926829636096954" z=".8598478436470032"/>
-			
-		
-			<Velocity x=".36876925826072693" y=".662164568901062" z=".6691066026687622"/>
-			
-		
-			<Velocity x="-.05499390885233879" y="-.4663749039173126" z="-.4088318645954132"/>
-			
-		
-			<Velocity x=".7102882266044617" y="-.48325785994529724" z=".11342495679855347"/>
-			
-		
-			<Velocity x="-1.077205777168274" y="-.23069259524345398" z=".4942651391029358"/>
-			
-		
-			<Velocity x="-.910267174243927" y="-.04035577178001404" z="-.09058812260627747"/>
-			
-		
-			<Velocity x="-.3481391370296478" y=".03991318494081497" z="-.10215670615434647"/>
-			
-		
-			<Velocity x="-.12122606486082077" y="-.0775386244058609" z="-.8606213331222534"/>
-			
-		
-			<Velocity x="-.5210204124450684" y=".15808819234371185" z="-1.2352745532989502"/>
-			
-		
-			<Velocity x=".3658278286457062" y="-.07093043625354767" z="-.059481244534254074"/>
-			
-		
-			<Velocity x="-.4796767830848694" y="-.13125669956207275" z=".26141420006752014"/>
-			
-		
-			<Velocity x="-.33156052231788635" y=".4019615650177002" z=".43808504939079285"/>
-			
-		
-			<Velocity x=".28116127848625183" y="-.1394045650959015" z=".5338665843009949"/>
-			
-		
-			<Velocity x=".5469166040420532" y=".43495380878448486" z=".6629016995429993"/>
-			
-		
-			<Velocity x=".42409735918045044" y=".6751332879066467" z="-.29757532477378845"/>
-			
-		
-			<Velocity x="-.8667908906936646" y=".06653705984354019" z="-.02630460448563099"/>
-			
-		
-			<Velocity x="-.10006237775087357" y=".7962746620178223" z=".5554803609848022"/>
-			
-		
-			<Velocity x="-.7398888468742371" y="-.49997392296791077" z="-.1800140142440796"/>
-			
-		
-			<Velocity x="-.07096385955810547" y="1.6306545734405518" z="-.19593562185764313"/>
-			
-		
-			<Velocity x="-.36152827739715576" y=".40765365958213806" z="-.0632811188697815"/>
-			
-		
-			<Velocity x=".023373406380414963" y="-.28944215178489685" z="-.3553315997123718"/>
-			
-		
-			<Velocity x=".8489535450935364" y=".19473432004451752" z="-.3274460732936859"/>
-			
-		
-			<Velocity x="-.0786655843257904" y="-.02571794204413891" z="-.46606799960136414"/>
-			
-		
-			<Velocity x="-.32274559140205383" y="-.1764613538980484" z=".04725894331932068"/>
-			
-		
-			<Velocity x="-.30066707730293274" y=".3849426209926605" z="-.2557334303855896"/>
-			
-		
-			<Velocity x="1.2540507316589355" y="-.39187344908714294" z="-.11816007643938065"/>
-			
-		
-			<Velocity x=".005914914887398481" y=".8893043398857117" z="-.72422194480896"/>
-			
-		
-			<Velocity x="-.3818052113056183" y="-.42145609855651855" z="-.15406706929206848"/>
-			
-		
-			<Velocity x=".44583749771118164" y=".3466683030128479" z=".4699142277240753"/>
-			
-		
-			<Velocity x=".43092724680900574" y=".4940531551837921" z=".10482698678970337"/>
-			
-		
-			<Velocity x=".07725880295038223" y=".08643429726362228" z="-.7818591594696045"/>
-			
-		
-			<Velocity x=".08242374658584595" y="-.43287062644958496" z=".6034529805183411"/>
-			
-		
-			<Velocity x=".41744428873062134" y=".29424500465393066" z=".4243795573711395"/>
-			
-		
-			<Velocity x=".6095775365829468" y=".08978837728500366" z="-.5813329219818115"/>
-			
-		
-			<Velocity x="-.9791262745857239" y="-.41389569640159607" z="-1.9850817918777466"/>
-			
-		
-			<Velocity x="-2.2443573474884033" y="1.400539755821228" z="-1.5651130676269531"/>
-			
-		
-			<Velocity x="-1.6726243495941162" y="-1.3184391260147095" z=".5255357027053833"/>
-			
-		
-			<Velocity x="-.6808992624282837" y="-1.3070621490478516" z="-.7648159861564636"/>
-			
-	
-		</Velocities>
-		
-	
-		<IntegratorParameters/>
-		
-
-	</State>
 </OpenMMSimulation>


### PR DESCRIPTION
Move the nanotube + methane simulation in the sim box to be in a better position for the player. Added the notebook for doing this to the directory containing the equilibration files.