### PR TITLE
Clear grab from grabbers when interaction manager is disabled

### DIFF
--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/Interaction/PinchGrabber.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/Interaction/PinchGrabber.cs
@@ -80,6 +80,12 @@ namespace NanoverImd.Subtle_Game.Interaction
             };
             Grab = InteractableScene.GetParticleGrab(grabPose);
         }
+
+        public void ClearGrab()
+        {
+            RemovePreviousGrab();
+            Grab = null;
+        }
         
         /// <summary>
         /// Call the functions to check if the player is interacting with the simulation.

--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/Interaction/UserInteractionManager.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/Interaction/UserInteractionManager.cs
@@ -155,6 +155,11 @@ namespace NanoverImd.Subtle_Game.Interaction
         {
             if (_pinchGrabbers == null || _pinchGrabbers.Any(grabber => grabber == null)) return;
             
+            foreach (var grabber in _pinchGrabbers)
+            {
+                grabber.ClearGrab();
+            }
+            
             var interactionsToRemove = simulation.Interactions.Keys
                 .Where(key => key.Contains("interaction."))
                 .ToList();


### PR DESCRIPTION
This ensures that interactions from previous tasks are not being applied at the beginning of the next task. Previously, interactions were being wiped at the end of a task, but then re-applied at the beginning of the next task. If the atom index for this interaction was out of range for the new simulation, then the server threw an error and broke the game.