### PR TITLE
Start Trials timer on first interaction

### DIFF
--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/Interaction/UserInteractionManager.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/Interaction/UserInteractionManager.cs
@@ -215,10 +215,13 @@ namespace NanoverImd.Subtle_Game.Interaction
                 grabber.ForceScale = 0;
             }
         }
-
-        public bool AllInteractionsHaveScaleZero()
+        
+        /// <summary>
+        /// Returns a bool representing whether a player is interacting with the simulation.
+        /// </summary>
+        public bool PlayerIsInteracting()
         {
-            return simulation.Interactions.Values.All(interaction => interaction.Scale == 0);
+            return simulation.Interactions.Values.Any(interaction => interaction.Scale != 0);
         }
     }
 }

--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/Interaction/UserInteractionManager.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/Interaction/UserInteractionManager.cs
@@ -215,5 +215,10 @@ namespace NanoverImd.Subtle_Game.Interaction
                 grabber.ForceScale = 0;
             }
         }
+
+        public bool AllInteractionsHaveScaleZero()
+        {
+            return simulation.Interactions.Values.All(interaction => interaction.Scale == 0);
+        }
     }
 }

--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/Interaction/UserInteractionManager.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/Interaction/UserInteractionManager.cs
@@ -217,7 +217,9 @@ namespace NanoverImd.Subtle_Game.Interaction
         }
         
         /// <summary>
-        /// Returns a bool representing whether a player is interacting with the simulation.
+        /// Returns a bool representing whether a player is interacting with the simulation. Note that there are always
+        /// two interactions in the shared state, but if these will have a scale of zero if the player is not
+        /// interacting.
         /// </summary>
         public bool PlayerIsInteracting()
         {

--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/SubtleGameManager.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/SubtleGameManager.cs
@@ -539,13 +539,18 @@ namespace NanoverImd.Subtle_Game
             
             // Show simulation and begin timer for the trial
             ShowSimulation = true;
-            
+
+            _timer.SetTimerDuration();
+
+            simulation.PlayTrajectory();
+
             // Wait until the player interacts
-            while (_userInteractionManager.AllInteractionsHaveScaleZero())
+            Debug.Log("Waiting for player interaction: " + _userInteractionManager.PlayerIsInteracting());
+            while (!_userInteractionManager.PlayerIsInteracting())
             {
                 yield return null; // Wait for the next frame
             }
-            
+
             _timer.StartTimer();
         }
 

--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/SubtleGameManager.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/SubtleGameManager.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Nanover.Core.Collections;
 using NanoverImd.Subtle_Game.Canvas;
 using NanoverImd.Subtle_Game.Data_Collection;
 using NanoverIMD.Subtle_Game.Data_Collection;
@@ -538,6 +539,13 @@ namespace NanoverImd.Subtle_Game
             
             // Show simulation and begin timer for the trial
             ShowSimulation = true;
+            
+            // Wait until the player interacts
+            while (_userInteractionManager.AllInteractionsHaveScaleZero())
+            {
+                yield return null; // Wait for the next frame
+            }
+            
             _timer.StartTimer();
         }
 

--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/SubtleGameManager.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/SubtleGameManager.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Nanover.Core.Collections;
 using NanoverImd.Subtle_Game.Canvas;
 using NanoverImd.Subtle_Game.Data_Collection;
 using NanoverIMD.Subtle_Game.Data_Collection;
@@ -537,20 +536,18 @@ namespace NanoverImd.Subtle_Game
                 yield return new WaitForSeconds(1f);
             }
             
-            // Show simulation and begin timer for the trial
+            // Show & start simulation, get the timer ready
             ShowSimulation = true;
-
-            _timer.SetTimerDuration();
-
             simulation.PlayTrajectory();
-
+            _timer.ResetTimerForBeginningOfTrial();
+            
             // Wait until the player interacts
-            Debug.Log("Waiting for player interaction: " + _userInteractionManager.PlayerIsInteracting());
             while (!_userInteractionManager.PlayerIsInteracting())
             {
-                yield return null; // Wait for the next frame
+                yield return null;
             }
-
+            
+            // Start the timer
             _timer.StartTimer();
         }
 

--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Canvas/TrialsTimer.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Canvas/TrialsTimer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Collections;
+using NanoverImd.Subtle_Game.Interaction;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -10,6 +11,7 @@ namespace NanoverImd.Subtle_Game.Canvas
     public class TrialsTimer : MonoBehaviour
     {
         [SerializeField] private SubtleGameManager subtleGameManager;
+        [SerializeField] private UserInteractionManager _userInteractionManager;
 
 
         // <summary>
@@ -46,7 +48,9 @@ namespace NanoverImd.Subtle_Game.Canvas
         private void Update()
         {
             // Check if timer is running
-            if (!_timerIsRunning) return;
+            if (!_timerIsRunning){
+                return;
+            }
 
             if (finishTrialEarly || _timeElapsed >= _duration)
             {
@@ -60,7 +64,8 @@ namespace NanoverImd.Subtle_Game.Canvas
             UpdateTimerVisuals();
         }
         
-        public void StartTimer()
+
+        public void SetTimerDuration()
         {
             switch (subtleGameManager.CurrentTaskType)
             {
@@ -75,13 +80,21 @@ namespace NanoverImd.Subtle_Game.Canvas
                                      "not in one of the trials tasks?");
                     break;
             }
+            
+            timerLabel.text = _duration.ToString();
+            timerImage.fillAmount = 1.0f;
+
             finishTrialEarly = false;
-            subtleGameManager.simulation.PlayTrajectory();
+        }
+        
+        
+        public void StartTimer()
+        {
             _timerIsRunning = true;
             _timeElapsed = 0;
-            timerImage.fillAmount = 0;
             answerNowButton.Enable();
         }
+        
 
         private void FinishTimer(string timeElapsed)
         {

--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Canvas/TrialsTimer.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Canvas/TrialsTimer.cs
@@ -1,31 +1,23 @@
-﻿using System;
-using System.Globalization;
-using System.Collections;
+﻿using System.Collections;
+using NanoverImd.Subtle_Game;
+using NanoverImd.Subtle_Game.Canvas;
 using NanoverImd.Subtle_Game.Interaction;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 
-namespace NanoverImd.Subtle_Game.Canvas
+namespace NanoverIMD.Subtle_Game.UI.Canvas
 {
     public class TrialsTimer : MonoBehaviour
     {
         [SerializeField] private SubtleGameManager subtleGameManager;
-        [SerializeField] private UserInteractionManager _userInteractionManager;
-
-
-        // <summary>
-        // A link to the Answer Now button to enable/disable it
-        // <summary>
+        [SerializeField] private UserInteractionManager userInteractionManager;
         [SerializeField] private ButtonController answerNowButton;
-
-        
         [SerializeField] private Image timerImage;
         [SerializeField] private TextMeshProUGUI timerLabel;
 
-        private bool _timerIsRunning;
-        private float _timeElapsed;
-
+        private bool _isTimerRunning;
+        private float _elapsedTime;
         private float _durationTrials;
         private float _durationTrialsTraining;
         private float _duration;
@@ -34,8 +26,18 @@ namespace NanoverImd.Subtle_Game.Canvas
         
         private void Start()
         {
-            if (timerImage != null) return;
-            Debug.LogError("Timer Image is not assigned!");
+            if (timerImage == null)
+            {
+                Debug.LogError("Timer Image is not assigned!");
+                return;
+            }
+            
+            if (answerNowButton == null)
+            {
+                Debug.LogError("Answer Now Button is not assigned!");
+                return;
+            }
+
             answerNowButton.Enable();
         }
 
@@ -47,89 +49,83 @@ namespace NanoverImd.Subtle_Game.Canvas
 
         private void Update()
         {
-            // Check if timer is running
-            if (!_timerIsRunning){
-                return;
-            }
+            if (!_isTimerRunning) return;
 
-            if (finishTrialEarly || _timeElapsed >= _duration)
+            if (finishTrialEarly || _elapsedTime >= _duration)
             {
-                FinishTimer(_timeElapsed.ToString());
+                FinishTimer(_elapsedTime.ToString());
                 return;
             }
 
-            // Increment timer
-            _timeElapsed += Time.deltaTime;
-
+            // Update the timer
+            _elapsedTime += Time.deltaTime;
             UpdateTimerVisuals();
         }
         
-
-        public void SetTimerDuration()
+        /// <summary>
+        /// Resets the timer icon for the beginning of a Trial.
+        /// </summary>
+        public void ResetTimerForBeginningOfTrial()
         {
-            switch (subtleGameManager.CurrentTaskType)
+            // Determine task type and set duration
+            _duration = subtleGameManager.CurrentTaskType switch
             {
-                case SubtleGameManager.TaskTypeVal.Trials or SubtleGameManager.TaskTypeVal.TrialsObserver:
-                    _duration = _durationTrials;
-                    break;
-                case SubtleGameManager.TaskTypeVal.TrialsTraining or SubtleGameManager.TaskTypeVal.TrialsObserverTraining:
-                    _duration = _durationTrialsTraining;
-                    break;
-                default:
-                    Debug.LogWarning("Probably shouldn't reach here, why have we started the timer when we are " +
-                                     "not in one of the trials tasks?");
-                    break;
-            }
+                SubtleGameManager.TaskTypeVal.Trials or SubtleGameManager.TaskTypeVal.TrialsObserver => _durationTrials,
+                SubtleGameManager.TaskTypeVal.TrialsTraining or SubtleGameManager.TaskTypeVal.TrialsObserverTraining => _durationTrialsTraining,
+                _ => throw new System.Exception("Unexpected task type when starting the timer.")
+            };
             
+            // Update the timer visuals & reset variables
             timerLabel.text = _duration.ToString();
             timerImage.fillAmount = 1.0f;
-
             finishTrialEarly = false;
         }
         
-        
+        /// <summary>
+        /// Starts the timer running and enables the "answer now" button.
+        /// </summary>
         public void StartTimer()
         {
-            _timerIsRunning = true;
-            _timeElapsed = 0;
+            _isTimerRunning = true;
+            _elapsedTime = 0;
             answerNowButton.Enable();
         }
         
-
+        /// <summary>
+        /// Called when the timer has stopped and player is making their selection.
+        /// </summary>
         private void FinishTimer(string timeElapsed)
         {
             subtleGameManager.DurationOfTrial = timeElapsed;
-            _timerIsRunning = false;
+            _isTimerRunning = false;
             subtleGameManager.FinishCurrentTrial();
             answerNowButton.Disable();
             StartCoroutine(AnimateTimerToZero());
         }
 
-        // <summary>
-        // A coroutine to animate lower the timer value to zero
-        // </summary>
-        IEnumerator AnimateTimerToZero()
+        /// <summary>
+        /// Smoothly animates the timer's visual countdown to zero.
+        /// </summary>
+        private IEnumerator AnimateTimerToZero()
         {
             while (timerImage.fillAmount > 0)
             {
-                _timeElapsed += 0.5f;
+                _elapsedTime += 0.5f;
                 UpdateTimerVisuals();
                 yield return new WaitForSeconds(0.01f);
             }
-            
         }
 
-        // <summary>
-        // Refresh the number label and the circular graph base on the global _timeElapsed value
-        // </summary>
+        /// <summary>
+        /// Updates the timer label and circular timer fill amount.
+        /// </summary>
         private void UpdateTimerVisuals()
         {
-            timerImage.fillAmount = (_duration - _timeElapsed) / _duration ;
+            timerImage.fillAmount = (_duration - _elapsedTime) / _duration ;
+            var label = Mathf.CeilToInt ( _duration - _elapsedTime );
+            timerLabel.text = label.ToString();
 
-            int _label = Mathf.CeilToInt ( _duration - _timeElapsed );
-            timerLabel.text = _label.ToString();
-
-            if (_duration - _timeElapsed < 0.1) {
+            if (_duration - _elapsedTime < 0.1) {
                 timerLabel.text = "0";
             }
         }

--- a/Client/vr-client/Assets/Scenes/Main.unity
+++ b/Client/vr-client/Assets/Scenes/Main.unity
@@ -25895,6 +25895,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   subtleGameManager: {fileID: 1364228086}
+  userInteractionManager: {fileID: 50482152}
   answerNowButton: {fileID: 664773393}
   timerImage: {fileID: 898926699}
   timerLabel: {fileID: 991938752}


### PR DESCRIPTION
The Trials timer now starts once the player has started interacting with the molecule. The logic works fine, but it's worth noting that sometimes the player interacts without meaning to (especially with the hand tracking), so the timer may start before they want.