### PR TITLE
Add check for Observer trials when starting trials timer

### DIFF
--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/SubtleGameManager.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/SubtleGameManager.cs
@@ -541,13 +541,14 @@ namespace NanoverImd.Subtle_Game
             simulation.PlayTrajectory();
             _timer.ResetTimerForBeginningOfTrial();
             
-            // Wait until the player interacts
-            while (!_userInteractionManager.PlayerIsInteracting())
-            {
-                yield return null;
+            // If not an Observer Trial, wait until the player interacts to start the timer
+            if (!TaskLists.ObserverTrialsTasks.Contains(CurrentTaskType)){
+                while (!_userInteractionManager.PlayerIsInteracting())
+                {
+                    yield return null;
+                }
             }
             
-            // Start the timer
             _timer.StartTimer();
         }
 


### PR DESCRIPTION
Add a check if we are in an Observer Trial, if so, then we don't wait for the player to interact (because they will not be interacting).