### PR TITLE
Disable "answer now" button before trials timer starts

### DIFF
--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Canvas/TrialsTimer.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Canvas/TrialsTimer.cs
@@ -16,7 +16,7 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
         [SerializeField] private Image timerImage;
         [SerializeField] private TextMeshProUGUI timerLabel;
 
-        private bool _isTimerRunning;
+        private bool _timerIsRunning;
         private float _elapsedTime;
         private float _durationTrials;
         private float _durationTrialsTraining;
@@ -46,20 +46,16 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
             _durationTrials = PlayerPrefs.GetFloat(SubtleGameManager.TrialTimeLimit);
             _durationTrialsTraining = PlayerPrefs.GetFloat(SubtleGameManager.TrialTrainingTimeLimit);
         }
-
-        private bool allowAnswerNow = false;
-
+        
         private void Update()
         {
-            if (allowAnswerNow) {
-                answerNowButton.Enable();
-            } 
-            else
+            if (!_timerIsRunning)
             {
-                answerNowButton.Disable();
+                answerNowButton.Disable(); // Player cannot press the "answer now" button if the timer isn't running
+                return;
             }
             
-            if (!_isTimerRunning) return;
+            answerNowButton.Enable();
 
             if (finishTrialEarly || _elapsedTime >= _duration)
             {
@@ -89,8 +85,6 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
             timerLabel.text = _duration.ToString();
             timerImage.fillAmount = 1.0f;
             finishTrialEarly = false;
-            answerNowButton.Disable();
-            allowAnswerNow = false;
         }
         
         /// <summary>
@@ -98,10 +92,8 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
         /// </summary>
         public void StartTimer()
         {
-            _isTimerRunning = true;
+            _timerIsRunning = true;
             _elapsedTime = 0;
-            answerNowButton.Enable();
-            allowAnswerNow = true;
         }
         
         /// <summary>
@@ -110,11 +102,8 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
         private void FinishTimer(string timeElapsed)
         {
             subtleGameManager.DurationOfTrial = timeElapsed;
-            _isTimerRunning = false;
+            _timerIsRunning = false;
             subtleGameManager.FinishCurrentTrial();
-            answerNowButton.Disable();
-            allowAnswerNow = false;
-            
             StartCoroutine(AnimateTimerToZero());
         }
 

--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Canvas/TrialsTimer.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Canvas/TrialsTimer.cs
@@ -51,10 +51,12 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
         {
             if (!_timerIsRunning)
             {
-                answerNowButton.Disable(); // Player cannot press the "answer now" button if the timer isn't running
+                // Player cannot press the "answer now" button if the timer isn't running
+                if (answerNowButton.isActiveAndEnabled) answerNowButton.Disable(); 
                 return;
             }
             
+            // Enable the "answer now" button
             answerNowButton.Enable();
 
             if (finishTrialEarly || _elapsedTime >= _duration)

--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Canvas/TrialsTimer.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Canvas/TrialsTimer.cs
@@ -47,8 +47,18 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
             _durationTrialsTraining = PlayerPrefs.GetFloat(SubtleGameManager.TrialTrainingTimeLimit);
         }
 
+        private bool allowAnswerNow = false;
+
         private void Update()
         {
+            if (allowAnswerNow) {
+                answerNowButton.Enable();
+            } 
+            else
+            {
+                answerNowButton.Disable();
+            }
+            
             if (!_isTimerRunning) return;
 
             if (finishTrialEarly || _elapsedTime >= _duration)
@@ -79,6 +89,8 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
             timerLabel.text = _duration.ToString();
             timerImage.fillAmount = 1.0f;
             finishTrialEarly = false;
+            answerNowButton.Disable();
+            allowAnswerNow = false;
         }
         
         /// <summary>
@@ -89,6 +101,7 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
             _isTimerRunning = true;
             _elapsedTime = 0;
             answerNowButton.Enable();
+            allowAnswerNow = true;
         }
         
         /// <summary>
@@ -100,6 +113,8 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
             _isTimerRunning = false;
             subtleGameManager.FinishCurrentTrial();
             answerNowButton.Disable();
+            allowAnswerNow = false;
+            
             StartCoroutine(AnimateTimerToZero());
         }
 


### PR DESCRIPTION
Stop the "answer now" button in the Trials task from being enabled unless the timer has started.