### PR TITLE
Duplicate answer now button on left side of simulation box

### DIFF
--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/SubtleGameManager.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/SubtleGameManager.cs
@@ -580,7 +580,7 @@ namespace NanoverImd.Subtle_Game
         /// </summary>
         public void FinishTrialEarly()
         {
-            trialsTimer.finishTrialEarly = true;
+            trialsTimer.FinishTrialEarly = true;
         }
         
         /// <summary>

--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Canvas/TaskInstructionsManager.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Canvas/TaskInstructionsManager.cs
@@ -5,6 +5,7 @@ using NanoverImd.Subtle_Game.Data_Collection;
 using NanoverIMD.Subtle_Game.Data_Collection;
 using NanoverImd.Subtle_Game.Interaction;
 using NanoverImd.Subtle_Game.UI.Simulation;
+using NanoverIMD.Subtle_Game.UI.Simulation;
 using UnityEngine;
 using UnityEngine.Serialization;
 
@@ -63,9 +64,19 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
         [SerializeField] private UserInteractionManager userInteractionManager;
         
         /// <summary>
-        /// The game object representing the center of the XY plane of the simulation box.
+        /// The game object representing the center of the right face the simulation box.
         /// </summary>
         [SerializeField] private CenterRightFace centerRightFace;
+        
+        /// <summary>
+        /// The game object representing the center of the left face of the simulation box.
+        /// </summary>
+        [SerializeField] private CenterLeftFace centerLeftFace;
+        
+        /// <summary>
+        /// The game object representing the canvas on the left face of the simulation box.
+        /// </summary>
+        [SerializeField] private GameObject leftTaskInstructionsCanvas;
         
         /// <summary>
         /// The Trial Icon Manager.
@@ -120,14 +131,14 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
             if (_subtleGameManager is null) return;
 
             // To overcome race conditions, we position and setup the input instructions constantly
-            PlacePanelOnRightFaceOfSimBox();
+            PlacePanelCanvasesOnSimBox();
             SetupInputInstructions();
 
             // Check the following: the sim is showing and the panel is not already active
             if (_subtleGameManager.ShowSimulation && _panel.activeSelf==false)
             {
                 // Position panel
-                PlacePanelOnRightFaceOfSimBox();
+                PlacePanelCanvasesOnSimBox();
                 SetupLayout();
                 
                 // It takes a few frames for the box to be correctly positioned, so enable panel with slight delay
@@ -168,6 +179,7 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
             foreach (Transform child in _panel.transform)
             {
                 child.gameObject.SetActive(false);
+                leftTaskInstructionsCanvas.SetActive(false);
             }
 
             // activate the instruction objects required for each task type
@@ -192,6 +204,7 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
                     timer.SetActive(true);
                     trialProgressManager.gameObject.SetActive(true);
                     trialsProgressGroup.SetActive(true);
+                    leftTaskInstructionsCanvas.SetActive(true);
                     break;
             }
         }
@@ -213,12 +226,17 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
         }
         
         /// <summary>
-        /// Place the in-task instructions at right face of the simulation box.
+        /// Place the respective in-task instructions at right & left faces of the simulation box.
         /// </summary>
-        private void PlacePanelOnRightFaceOfSimBox()
+        private void PlacePanelCanvasesOnSimBox()
         {
+            // Place right-hand instructions
             gameObject.transform.position = centerRightFace.transform.position;
             gameObject.transform.rotation = centerRightFace.transform.rotation;
+            
+            // Place left-hand instructions
+            leftTaskInstructionsCanvas.transform.position = centerLeftFace.transform.position;
+            leftTaskInstructionsCanvas.transform.rotation = centerLeftFace.transform.rotation;
         }
 
         private void HandlePlayerIsSelectingAnswer(bool playerIsSelectingAnswer)

--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Canvas/TaskInstructionsManager.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Canvas/TaskInstructionsManager.cs
@@ -113,7 +113,7 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
         }
 
         /// <summary>
-        /// Updates the in-task instructions based on the current interaction modality set in the Pinch Grab script.
+        /// Updates the in-task instructions placed on the right-hand face of the simulation box.
         /// </summary>
         private void LateUpdate()
         {
@@ -123,7 +123,7 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
             PlacePanelOnRightFaceOfSimBox();
             SetupInputInstructions();
 
-            // Check the following: the sim is showing, the panel is not already active, and the task has changed
+            // Check the following: the sim is showing and the panel is not already active
             if (_subtleGameManager.ShowSimulation && _panel.activeSelf==false)
             {
                 // Position panel

--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Canvas/TrialsTimer.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Canvas/TrialsTimer.cs
@@ -4,7 +4,6 @@ using NanoverImd.Subtle_Game.Canvas;
 using NanoverImd.Subtle_Game.Interaction;
 using TMPro;
 using UnityEngine;
-using UnityEngine.Serialization;
 using UnityEngine.UI;
 
 namespace NanoverIMD.Subtle_Game.UI.Canvas
@@ -23,9 +22,11 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
         private float _durationTrials;
         private float _durationTrialsTraining;
         private float _duration;
-        
+
         public bool finishTrialEarly;
         
+        private ButtonController[] _answerNowButtons;
+
         private void Start()
         {
             if (timerImage == null)
@@ -33,14 +34,20 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
                 Debug.LogError("Timer Image is not assigned!");
                 return;
             }
-            
-            if (rightAnswerNowButton == null)
-            {
-                Debug.LogError("Answer Now Button is not assigned!");
-                return;
-            }
 
-            rightAnswerNowButton.Enable();
+            // Initialize the array of answer now buttons
+            _answerNowButtons = new[] { leftAnswerNowButton, rightAnswerNowButton };
+
+            foreach (var button in _answerNowButtons)
+            {
+                if (button == null)
+                {
+                    Debug.LogError("One of the Answer Now buttons is not assigned!");
+                    return;
+                }
+
+                button.Enable(); // Enable buttons at start
+            }
         }
 
         private void OnEnable()
@@ -48,18 +55,18 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
             _durationTrials = PlayerPrefs.GetFloat(SubtleGameManager.TrialTimeLimit);
             _durationTrialsTraining = PlayerPrefs.GetFloat(SubtleGameManager.TrialTrainingTimeLimit);
         }
-        
+
         private void Update()
         {
             if (!_timerIsRunning)
             {
-                // Player cannot press the "answer now" button if the timer isn't running
-                if (rightAnswerNowButton.isActiveAndEnabled) rightAnswerNowButton.Disable(); 
+                // Disable buttons if the timer isn't running
+                SetButtonsActive(false);
                 return;
             }
-            
-            // Enable the "answer now" button
-            rightAnswerNowButton.Enable();
+
+            // Enable buttons
+            SetButtonsActive(true);
 
             if (finishTrialEarly || _elapsedTime >= _duration)
             {
@@ -71,35 +78,39 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
             _elapsedTime += Time.deltaTime;
             UpdateTimerVisuals();
         }
-        
+
         /// <summary>
         /// Resets the timer icon for the beginning of a Trial.
         /// </summary>
         public void ResetTimerForBeginningOfTrial()
         {
-            // Determine task type and set duration
             _duration = subtleGameManager.CurrentTaskType switch
             {
                 SubtleGameManager.TaskTypeVal.Trials or SubtleGameManager.TaskTypeVal.TrialsObserver => _durationTrials,
                 SubtleGameManager.TaskTypeVal.TrialsTraining or SubtleGameManager.TaskTypeVal.TrialsObserverTraining => _durationTrialsTraining,
                 _ => throw new System.Exception("Unexpected task type when starting the timer.")
             };
-            
-            // Update the timer visuals & reset variables
+
             timerLabel.text = _duration.ToString();
             timerImage.fillAmount = 0.0f;
             finishTrialEarly = false;
+
+            // Disable buttons at the start of a new trial
+            SetButtonsActive(false);
         }
-        
+
         /// <summary>
-        /// Starts the timer running and enables the "answer now" button.
+        /// Starts the timer running.
         /// </summary>
         public void StartTimer()
         {
             _timerIsRunning = true;
             _elapsedTime = 0;
+
+            // Enable buttons when the timer starts
+            SetButtonsActive(true);
         }
-        
+
         /// <summary>
         /// Called when the timer has stopped and player is making their selection.
         /// </summary>
@@ -109,6 +120,9 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
             _timerIsRunning = false;
             subtleGameManager.FinishCurrentTrial();
             StartCoroutine(AnimateTimerToZero());
+
+            // Disable buttons once the timer ends
+            SetButtonsActive(false);
         }
 
         /// <summary>
@@ -129,14 +143,31 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
         /// </summary>
         private void UpdateTimerVisuals()
         {
-            timerImage.fillAmount = (_duration - _elapsedTime) / _duration ;
-            var label = Mathf.CeilToInt ( _duration - _elapsedTime );
+            timerImage.fillAmount = (_duration - _elapsedTime) / _duration;
+            var label = Mathf.CeilToInt(_duration - _elapsedTime);
             timerLabel.text = label.ToString();
 
-            if (_duration - _elapsedTime < 0.1) {
+            if (_duration - _elapsedTime < 0.1)
+            {
                 timerLabel.text = "0";
             }
         }
 
+        /// <summary>
+        /// Helper method to set both buttons' active state.
+        /// </summary>
+        private void SetButtonsActive(bool isActive)
+        {
+
+            if (_answerNowButtons == null) return;
+            
+            foreach (var button in _answerNowButtons)
+            {
+                if (isActive)
+                    button.Enable();
+                else
+                    button.Disable();
+            }
+        }
     }
 }

--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Canvas/TrialsTimer.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Canvas/TrialsTimer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using NanoverImd.Subtle_Game;
 using NanoverImd.Subtle_Game.Canvas;
 using NanoverImd.Subtle_Game.Interaction;
@@ -23,7 +24,7 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
         private float _durationTrialsTraining;
         private float _duration;
 
-        public bool finishTrialEarly;
+        [NonSerialized] public bool FinishTrialEarly;
         
         private ButtonController[] _answerNowButtons;
 
@@ -60,15 +61,16 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
         {
             if (!_timerIsRunning)
             {
-                // Disable buttons if the timer isn't running
+                // Set buttons' states to disabled if the timer isn't running
                 SetButtonsActive(false);
                 return;
             }
 
-            // Enable buttons
+            // Allow player to press the buttons
             SetButtonsActive(true);
-
-            if (finishTrialEarly || _elapsedTime >= _duration)
+            
+            // Check if the timer has finished or the player pressed a button
+            if (FinishTrialEarly || _elapsedTime >= _duration)
             {
                 FinishTimer(_elapsedTime.ToString());
                 return;
@@ -93,9 +95,9 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
 
             timerLabel.text = _duration.ToString();
             timerImage.fillAmount = 0.0f;
-            finishTrialEarly = false;
+            FinishTrialEarly = false;
 
-            // Disable buttons at the start of a new trial
+            // Set buttons' states to disabled at the start of a new trial
             SetButtonsActive(false);
         }
 
@@ -107,7 +109,7 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
             _timerIsRunning = true;
             _elapsedTime = 0;
 
-            // Enable buttons when the timer starts
+            // Make buttons pressable when the timer starts
             SetButtonsActive(true);
         }
 
@@ -121,7 +123,7 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
             subtleGameManager.FinishCurrentTrial();
             StartCoroutine(AnimateTimerToZero());
 
-            // Disable buttons once the timer ends
+            // Set buttons' states to disabled once the timer ends
             SetButtonsActive(false);
         }
 
@@ -154,11 +156,10 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
         }
 
         /// <summary>
-        /// Helper method to set both buttons' active state.
+        /// Sets the state of the Answer Now buttons
         /// </summary>
         private void SetButtonsActive(bool isActive)
         {
-
             if (_answerNowButtons == null) return;
             
             foreach (var button in _answerNowButtons)

--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Canvas/TrialsTimer.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Canvas/TrialsTimer.cs
@@ -4,6 +4,7 @@ using NanoverImd.Subtle_Game.Canvas;
 using NanoverImd.Subtle_Game.Interaction;
 using TMPro;
 using UnityEngine;
+using UnityEngine.Serialization;
 using UnityEngine.UI;
 
 namespace NanoverIMD.Subtle_Game.UI.Canvas
@@ -12,7 +13,8 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
     {
         [SerializeField] private SubtleGameManager subtleGameManager;
         [SerializeField] private UserInteractionManager userInteractionManager;
-        [SerializeField] private ButtonController answerNowButton;
+        [SerializeField] private ButtonController rightAnswerNowButton;
+        [SerializeField] private ButtonController leftAnswerNowButton;
         [SerializeField] private Image timerImage;
         [SerializeField] private TextMeshProUGUI timerLabel;
 
@@ -32,13 +34,13 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
                 return;
             }
             
-            if (answerNowButton == null)
+            if (rightAnswerNowButton == null)
             {
                 Debug.LogError("Answer Now Button is not assigned!");
                 return;
             }
 
-            answerNowButton.Enable();
+            rightAnswerNowButton.Enable();
         }
 
         private void OnEnable()
@@ -52,12 +54,12 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
             if (!_timerIsRunning)
             {
                 // Player cannot press the "answer now" button if the timer isn't running
-                if (answerNowButton.isActiveAndEnabled) answerNowButton.Disable(); 
+                if (rightAnswerNowButton.isActiveAndEnabled) rightAnswerNowButton.Disable(); 
                 return;
             }
             
             // Enable the "answer now" button
-            answerNowButton.Enable();
+            rightAnswerNowButton.Enable();
 
             if (finishTrialEarly || _elapsedTime >= _duration)
             {

--- a/Client/vr-client/Assets/Scenes/Main.unity
+++ b/Client/vr-client/Assets/Scenes/Main.unity
@@ -28516,7 +28516,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   subtleGameManager: {fileID: 1364228086}
   userInteractionManager: {fileID: 50482152}
-  answerNowButton: {fileID: 664773393}
+  rigthAnswerNowButton: {fileID: 664773393}
+  leftAnswerNowButton: {fileID: 533639768}
   timerImage: {fileID: 898926699}
   timerLabel: {fileID: 991938752}
   finishTrialEarly: 0

--- a/Client/vr-client/Assets/Scenes/Main.unity
+++ b/Client/vr-client/Assets/Scenes/Main.unity
@@ -7692,7 +7692,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 374303654028433922, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 733
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 374303654028433922, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
       propertyPath: m_LocalPosition.y
@@ -7955,7 +7955,10 @@ PrefabInstance:
     - {fileID: 656991192480398139, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
     - {fileID: 3246337340863214673, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 6406907961171276735, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
   m_SourcePrefab: {fileID: 100100000, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
 --- !u!4 &533639766 stripped
 Transform:
@@ -13538,7 +13541,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -20}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1001 &983291241

--- a/Client/vr-client/Assets/Scenes/Main.unity
+++ b/Client/vr-client/Assets/Scenes/Main.unity
@@ -7955,10 +7955,7 @@ PrefabInstance:
     - {fileID: 656991192480398139, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
     - {fileID: 3246337340863214673, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
     m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 6406907961171276735, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
 --- !u!4 &533639766 stripped
 Transform:
@@ -28516,7 +28513,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   subtleGameManager: {fileID: 1364228086}
   userInteractionManager: {fileID: 50482152}
-  rigthAnswerNowButton: {fileID: 664773393}
+  rightAnswerNowButton: {fileID: 664773393}
   leftAnswerNowButton: {fileID: 533639768}
   timerImage: {fileID: 898926699}
   timerLabel: {fileID: 991938752}

--- a/Client/vr-client/Assets/Scenes/Main.unity
+++ b/Client/vr-client/Assets/Scenes/Main.unity
@@ -7654,6 +7654,336 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 520918504}
   m_CullTransparentMesh: 1
+--- !u!1001 &533639765
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 978176606}
+    m_Modifications:
+    - target: {fileID: 126997455834770876, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _whenSelect.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 126997455834770876, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _whenSelect.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 126997455834770876, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _whenSelect.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 533639768}
+    - target: {fileID: 126997455834770876, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _whenSelect.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 126997455834770876, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _whenSelect.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: ButtonFinishTrialEarly
+      objectReference: {fileID: 0}
+    - target: {fileID: 126997455834770876, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _whenSelect.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: NarupaIMD.Subtle_Game.Canvas.ButtonController, NarupaImd
+      objectReference: {fileID: 0}
+    - target: {fileID: 126997455834770876, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _whenSelect.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 374303654028433922, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 733
+      objectReference: {fileID: 0}
+    - target: {fileID: 374303654028433922, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 257
+      objectReference: {fileID: 0}
+    - target: {fileID: 374303654028433922, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -118
+      objectReference: {fileID: 0}
+    - target: {fileID: 374303654028433922, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9659258
+      objectReference: {fileID: 0}
+    - target: {fileID: 374303654028433922, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.2588191
+      objectReference: {fileID: 0}
+    - target: {fileID: 374303654028433922, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 374303654028433922, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 374303654028433922, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 374303654028433922, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 374303654028433922, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1579710612413160461, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _color.a
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1579710612413160461, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _color.b
+      value: 0.5896226
+      objectReference: {fileID: 0}
+    - target: {fileID: 1579710612413160461, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _color.g
+      value: 0.40417165
+      objectReference: {fileID: 0}
+    - target: {fileID: 1579710612413160461, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _color.r
+      value: 0.3309674
+      objectReference: {fileID: 0}
+    - target: {fileID: 1579710612413160461, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _borderColor.a
+      value: 0.9019608
+      objectReference: {fileID: 0}
+    - target: {fileID: 1579710612413160461, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _borderColor.b
+      value: 0.03404236
+      objectReference: {fileID: 0}
+    - target: {fileID: 1579710612413160461, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _borderColor.g
+      value: 0.12591752
+      objectReference: {fileID: 0}
+    - target: {fileID: 1579710612413160461, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _borderColor.r
+      value: 0.4811321
+      objectReference: {fileID: 0}
+    - target: {fileID: 1579710612413160461, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _borderOuterRadius
+      value: 0.05
+      objectReference: {fileID: 0}
+    - target: {fileID: 1888835162031061807, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: m_Name
+      value: Answer now
+      objectReference: {fileID: 0}
+    - target: {fileID: 1888835162031061807, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2879180694161153714, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: m_text
+      value: answer now
+      objectReference: {fileID: 0}
+    - target: {fileID: 2879180694161153714, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: m_fontSize
+      value: 34
+      objectReference: {fileID: 0}
+    - target: {fileID: 2879180694161153714, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: m_fontAsset
+      value: 
+      objectReference: {fileID: 11400000, guid: 44df6751171cc92499028b7603d8b151, type: 2}
+    - target: {fileID: 2879180694161153714, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: m_fontStyle
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 2879180694161153714, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 34
+      objectReference: {fileID: 0}
+    - target: {fileID: 2879180694161153714, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: m_sharedMaterial
+      value: 
+      objectReference: {fileID: -7717410991123242693, guid: 44df6751171cc92499028b7603d8b151, type: 2}
+    - target: {fileID: 2879180694161153714, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: m_hasFontAssetChanged
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3273843656128701680, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: m_SortingLayer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3942874763290783530, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: m_SortingLayer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4230122313901903156, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _color.a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4230122313901903156, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _color.b
+      value: 0.09019608
+      objectReference: {fileID: 0}
+    - target: {fileID: 4230122313901903156, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _color.g
+      value: 0.43921572
+      objectReference: {fileID: 0}
+    - target: {fileID: 4230122313901903156, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _color.r
+      value: 0.9607844
+      objectReference: {fileID: 0}
+    - target: {fileID: 4230122313901903156, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _borderColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4230122313901903156, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _borderColor.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4230122313901903156, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _borderColor.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4398372598149366373, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: m_SortingLayer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4398372598149366373, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: -7717410991123242693, guid: 44df6751171cc92499028b7603d8b151, type: 2}
+    - target: {fileID: 5178922036521567778, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: m_SortingLayer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5723141132105327143, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: m_SortingLayer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6558639594223844805, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _hoverColorState.Color.a
+      value: 0.6392157
+      objectReference: {fileID: 0}
+    - target: {fileID: 6558639594223844805, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _hoverColorState.Color.b
+      value: 0.09019608
+      objectReference: {fileID: 0}
+    - target: {fileID: 6558639594223844805, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _hoverColorState.Color.g
+      value: 0.34800115
+      objectReference: {fileID: 0}
+    - target: {fileID: 6558639594223844805, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _hoverColorState.Color.r
+      value: 0.9607843
+      objectReference: {fileID: 0}
+    - target: {fileID: 6558639594223844805, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _normalColorState.Color.a
+      value: 0.9098039
+      objectReference: {fileID: 0}
+    - target: {fileID: 6558639594223844805, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _normalColorState.Color.b
+      value: 0.09019608
+      objectReference: {fileID: 0}
+    - target: {fileID: 6558639594223844805, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _normalColorState.Color.g
+      value: 0.4392157
+      objectReference: {fileID: 0}
+    - target: {fileID: 6558639594223844805, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _normalColorState.Color.r
+      value: 0.9607843
+      objectReference: {fileID: 0}
+    - target: {fileID: 6558639594223844805, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _selectColorState.Color.a
+      value: 0.9098039
+      objectReference: {fileID: 0}
+    - target: {fileID: 6558639594223844805, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _selectColorState.Color.b
+      value: 0.09019608
+      objectReference: {fileID: 0}
+    - target: {fileID: 6558639594223844805, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _selectColorState.Color.g
+      value: 0.38387007
+      objectReference: {fileID: 0}
+    - target: {fileID: 6558639594223844805, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _selectColorState.Color.r
+      value: 0.9607843
+      objectReference: {fileID: 0}
+    - target: {fileID: 6558639594223844805, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _disabledColorState.Color.a
+      value: 0.34901962
+      objectReference: {fileID: 0}
+    - target: {fileID: 6558639594223844805, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _disabledColorState.Color.b
+      value: 0.3301887
+      objectReference: {fileID: 0}
+    - target: {fileID: 6558639594223844805, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _disabledColorState.Color.g
+      value: 0.3301887
+      objectReference: {fileID: 0}
+    - target: {fileID: 6558639594223844805, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _disabledColorState.Color.r
+      value: 0.3301887
+      objectReference: {fileID: 0}
+    - target: {fileID: 7275400478978886685, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7280395634042062615, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: m_SortingLayer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7607808710621774589, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: button
+      value: 
+      objectReference: {fileID: 533639767}
+    - target: {fileID: 8244291292108827354, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8244291292108827354, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8656136991598422196, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _color.b
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8656136991598422196, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _color.g
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8656136991598422196, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+      propertyPath: _color.r
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 656991192480398139, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+    - {fileID: 3246337340863214673, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+--- !u!4 &533639766 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 374303654028433922, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+  m_PrefabInstance: {fileID: 533639765}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &533639767 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5370227438908596707, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+  m_PrefabInstance: {fileID: 533639765}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 317e663e2bb60ea408fe22b908b59295, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &533639768 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7607808710621774589, guid: 70ebd0272d0607e4d81047f95a1fd98c, type: 3}
+  m_PrefabInstance: {fileID: 533639765}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 809ffb143fed47258cb9bbd013b1928b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &539088462 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 6652241100628516156, guid: 4be29d3cb086d8540a6175a41e05b7f4, type: 3}
@@ -11614,6 +11944,82 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 816916958}
   m_CullTransparentMesh: 1
+--- !u!1 &817998018
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 817998019}
+  - component: {fileID: 817998021}
+  - component: {fileID: 817998020}
+  m_Layer: 0
+  m_Name: Side panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &817998019
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 817998018}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1526195668}
+  m_Father: {fileID: 902312284}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 1000, y: -1000}
+  m_SizeDelta: {x: 2000, y: 2000}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &817998020
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 817998018}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.31132078, g: 0.31132078, b: 0.31132078, a: 0.23529412}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: ce21198c1b511d141b73ecf179e82fe7, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 0
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &817998021
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 817998018}
+  m_CullTransparentMesh: 1
 --- !u!1001 &827439022
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -12488,6 +12894,123 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &902312279
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 902312284}
+  - component: {fileID: 902312283}
+  - component: {fileID: 902312282}
+  - component: {fileID: 902312281}
+  - component: {fileID: 902312280}
+  m_Layer: 0
+  m_Name: Left Task Instructions
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!114 &902312280
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 902312279}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 570d1b332c6d4234b2b0a08b516cd2d0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  canvasType: 0
+  orderedListOfMenus: []
+--- !u!114 &902312281
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 902312279}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &902312282
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 902312279}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 1
+--- !u!223 &902312283
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 902312279}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &902312284
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 902312279}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 817998019}
+  m_Father: {fileID: 1149125435030198832}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 1000, y: 1000}
+  m_SizeDelta: {x: 2000, y: 2000}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &905877616
 GameObject:
   m_ObjectHideFlags: 0
@@ -12982,6 +13505,42 @@ CanvasGroup:
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0
+--- !u!1 &978176605
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 978176606}
+  m_Layer: 0
+  m_Name: Buttons
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &978176606
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 978176605}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 533639766}
+  m_Father: {fileID: 1526195668}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -20}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1001 &983291241
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -21743,6 +22302,8 @@ MonoBehaviour:
   exitInstructions: {fileID: 1484478698}
   userInteractionManager: {fileID: 50482152}
   centerRightFace: {fileID: 746467490}
+  centerLeftFace: {fileID: 724703621}
+  leftTaskInstructionsCanvas: {fileID: 902312279}
   trialProgressManager: {fileID: 1245036777}
   trialsProgressGroup: {fileID: 1839179447}
   trialAnswerSubmission: {fileID: 1364228087}
@@ -23833,6 +24394,42 @@ CanvasGroup:
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0
+--- !u!1 &1526195667
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1526195668}
+  m_Layer: 0
+  m_Name: Task instruction - Trials
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1526195668
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1526195667}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 978176606}
+  m_Father: {fileID: 817998019}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 1000, y: -1050}
+  m_SizeDelta: {x: 2000, y: 300}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1001 &1547352152
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -30243,6 +30840,7 @@ RectTransform:
   - {fileID: 723842363}
   - {fileID: 487962171}
   - {fileID: 1484478699}
+  - {fileID: 902312284}
   m_Father: {fileID: 8831589731561787294}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}


### PR DESCRIPTION
This PR adds a second "answer now" button during the Trials task that makes it easier for (a) left-handed players to press the button with their dominant hand and (b) any player to press the answer now button more easily from wherever they are positioned in the simulation box.