### PR TITLE
Update TrialsTimer.cs

### DIFF
--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Canvas/TrialsTimer.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Canvas/TrialsTimer.cs
@@ -106,8 +106,8 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
         /// </summary>
         public void StartTimer()
         {
-            _timerIsRunning = true;
             _elapsedTime = 0;
+            _timerIsRunning = true;
 
             // Make buttons pressable when the timer starts
             SetButtonsActive(true);


### PR DESCRIPTION
Switch order of things in TrialsTimer to try to stop the bug where the first trial skips straight to selecting as soon as the player interacts.