### PR TITLE
Update TrialsTimer.cs

### DIFF
--- a/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Canvas/TrialsTimer.cs
+++ b/Client/vr-client/Assets/NanoverIMD/Subtle Game/UI/Canvas/TrialsTimer.cs
@@ -27,6 +27,8 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
         [NonSerialized] public bool FinishTrialEarly;
         
         private ButtonController[] _answerNowButtons;
+        
+        private bool timerJustStarted = false;
 
         private void Start()
         {
@@ -64,6 +66,12 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
                 // Set buttons' states to disabled if the timer isn't running
                 SetButtonsActive(false);
                 return;
+            }
+            
+            if (timerJustStarted)
+            {
+                timerJustStarted = false;
+                return; // 🔁 Skip first frame check
             }
 
             // Allow player to press the buttons
@@ -107,6 +115,7 @@ namespace NanoverIMD.Subtle_Game.UI.Canvas
         public void StartTimer()
         {
             _elapsedTime = 0;
+            timerJustStarted = true;
             _timerIsRunning = true;
 
             // Make buttons pressable when the timer starts


### PR DESCRIPTION
Skip first frame after starting the timer, to see if this helps with the issue where the first training trial skips straight to selecting upon the first interaction.