### PR TITLE
Update run game script

### DIFF
--- a/Client/puppeteering_client.py
+++ b/Client/puppeteering_client.py
@@ -231,6 +231,7 @@ class PuppeteeringClient:
         print("Closing the puppeteering client and ending the game.")
         write_to_shared_state(client=self.nanover_client, key=KEY_END_TIME, value=str(get_current_time_in_spain()))
         write_to_shared_state(client=self.nanover_client, key=KEY_GAME_STATUS, value=FINISHED)
+        time.sleep(1)
         self.nanover_client.close()
         print('Game finished.')
 

--- a/Server/run_game.py
+++ b/Server/run_game.py
@@ -181,17 +181,28 @@ def run_game_with_subprocesses():
     # Start a separate thread to stream client output without blocking
     client_output_thread = threading.Thread(target=stream_subprocess_output, args=(client_process,))
     client_output_thread.start()
+    server_output_thread = threading.Thread(target=stream_subprocess_output, args=(server_process,))
+    server_output_thread.start()
 
     # Wait for client output to finish -- client process ended due to cleanup() or ctrl+c
     client_output_thread.join()
 
-    # Print out any errors from the puppeteering client
-    puppeteer_errors = client_process.stderr.read().strip()
-    if puppeteer_errors:
-        print(f"Error in puppeteering client:\n{puppeteer_errors}")
+    # Print out any errors from the server and puppeteering client
+    print_process_errors([p for p in [server_process, client_process] if p is not None])
 
     # cleanup if it didn't already happen
     cleanup(None, None)
+
+def print_process_errors(processes):
+    """Print any stderr output from the given list of processes."""
+    for process in processes:
+        if process is not None and process.stderr:
+            errors = process.stderr.read().strip()
+            if errors:
+                print(f"\nError in process (PID {process.pid}):\n{errors}")
+
+# Usage:
+print_process_errors([server_process, client_process])
 
 
 if __name__ == "__main__":

--- a/Server/run_game.py
+++ b/Server/run_game.py
@@ -130,7 +130,7 @@ def cleanup(signum=None, frame=None):
 
     stop_event.set()  # Signal the output thread to stop
 
-    print("All processes stopped. Exiting.")
+    print("All processes stopped. Exiting.\n-------------------------------------------------\n")
     sys.exit(0)
 
 # Register the cleanup function to catch SIGINT (CTRL+C) -- this replaces python's KeyboardInterrupt exception
@@ -180,7 +180,8 @@ def run_game_with_subprocesses():
     print(f"Client started with PID: {client_process.pid}")
 
     # Stream output of puppeteering client in real time
-    print("\nPuppeteering client output:")
+    print("\n-------------------------------------------------\nPrinting output from puppeteering client, "
+          "and output & errors from the server:\n-------------------------------------------------\n")
 
     # Start a thread to stream client output without blocking
     client_output_thread = threading.Thread(target=stream_subprocess_output, args=(client_process,))


### PR DESCRIPTION
This PR updates the run_game.py script in the following way:

- Most significantly, adds some time between terminating the puppeteering client and terminating the server.
- Updated the logic for running the cleanup function (that terminates the puppeteering client and server processes). 
- Updated the print statements, including printing the output & errors from the server on-the-fly.

We realised that sometimes the data from the final Trials task of the game is not recorded. We hope that these timing buffers fix this!